### PR TITLE
fix(README): fix example 

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ asar::create_template(
   year = 2010,
   author = c("John Snow", "Danny Phantom", "Patrick Star"),
   include_affiliation = TRUE,
-  parameters = FALSE,
   resdir = "C:/Users/Documents/Example_Files",
   model_results = "Report.sso",
   model = "SS3"


### PR DESCRIPTION
The example had parameters = FALSE, but the default child documents contained a reference to a parameter as an example for use in-text. This will be fixed by setting parameters = TRUE (default), but also by removing the line in the file.

We are redesigning this example and will provide an example folder where users can see the product of create_template, convert_output, and rendering of the quarto document (not in this PR)