### PR TITLE
add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,69 @@
+name: Bug Report
+description: Report asar not working as expected.
+title: "[Bug]: "
+labels: ["bug", "triage_needed"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report! Before
+        filling out this report please search the existing issues to see
+        if the problem has already been reported. If it has, please add a
+        comment to the open issue or link to the related, but closed, issue in
+        this report.
+  - type: textarea
+    id: describe
+    attributes:
+      label: Describe the bug
+      description: Please provide a description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Describe how to reproduce the bug
+      description: |
+        Please include a minimal reproducible example (i.e., a
+        [reprex]((https://reprex.tidyverse.org/articles/reprex-dos-and-donts.html))).
+        If you have not heard of a [reprex](http://reprex.tidyverse.org/)
+        before, you can start by reading about them on the [tidyverse
+        blog](https://www.tidyverse.org/help/#reprex). Feel free to copy, paste,
+        and edit the [demo
+        vignette](https://github.com/NOAA-FIMS/FIMS/blob/4539fc4b6e65b901231c4fb66a113bb5b5d54d22/vignettes/fims-demo.Rmd)
+        for your reprex.
+      placeholder: |
+        # insert reprex here
+    validations:
+      required: false
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If applicable, add screenshots to help explain your problem.
+    validations:
+      required: false
+  - type: dropdown
+    id: os
+    attributes:
+      label: Which OS are you seeing the problem on?
+      multiple: true
+      options:
+        - Windows
+        - Mac
+        - Linux
+        - Other
+    validations:
+      required: false
+  - type: input
+    id: version
+    attributes:
+      label: Which version of asar are you seeing the problem on?
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Add any other context about the problem here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,43 @@
+name: Feature Request
+description: Request new features or changes to features
+title: "[Feature]: "
+labels: ["enhancement", "triage_needed"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this feature request! Before
+        filling out this report please search the existing issues to see
+        if the problem has already been reported. If it has, please add a
+        comment to the open issue or link to the related, but closed, issue in
+        this report.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Is your feature request related to a problem? Please describe.
+      description: A clear and concise description of what the problem is.
+      placeholder: I'm always frustrated when...
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the solution you would like.
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Describe alternatives you have considered
+      description: A clear and concise description of any alternative solutions or features you have considered.
+      placeholder: Other solutions include ...
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots about the feature request here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,23 @@
+name: Question about asar
+description: Ask a question about asar
+title: "[Question]: "
+labels: ["question", "triage_needed"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to ask a question!
+  - type: textarea
+    id: question
+    attributes:
+      label: What is your question?
+      placeholder: Please ask a clear and concise question about asar.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots here.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+<!---
+Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
+-->
+
+# What is the feature?
+*
+
+# How have you implemented the solution?
+*
+
+# Does the PR impact any other area of the project, maybe another repo?
+*

--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -1,0 +1,44 @@
+# This workflow automatically adds a comment containing a reviewer checklist
+# when a new pull request is opened.
+name: Add a comment with reviewer checklist when PR opened
+on:
+  pull_request:
+    types: [opened]
+jobs:
+  pr-checklist:
+    runs-on: ubuntu-latest
+    name: pr-checklist
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: 'Comment PR'
+        uses: actions/github-script@0.3.0
+        if: github.event_name == 'pull_request'
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            var msg = `# Instructions for code reviewer
+
+            Hello reviewer, thanks for taking the time to review this PR!
+
+            - Please use this checklist during your review, checking off items that you have verified are complete!
+            - For PRs that don't make changes to code (e.g., changes to README.md or Github actions workflows), feel free to skip over items on the checklist that are not relevant. Remember it is still important to do a thorough review.
+            - Then, comment on the pull request with your review indicating where you have questions or changes need to be made before merging.
+            - Remember to review **every line of code** you’ve been asked to review, look at the context, make sure you’re improving code health, and compliment developers on good things that they do.
+            - PR reviews are a great way to learn, so feel free to share your tips and tricks. However, for optional changes (i.e., not required for merging), please include \`nit:\` (for nitpicking) before making the suggestion. For example, \`nit:\` I prefer using a \`data.frame()\` instead of a \`matrix\` because...
+            - Engage with the developer when they respond to comments and check off additional boxes as they become complete so the PR can be merged in when all the tasks are fulfilled. Make it clear when this has been reached by commenting on the PR with something like \`This PR is now ready to be merged, no changes needed\`.
+
+            ## Checklist
+
+            - [ ] The PR is requested to be merged into the appropriate branch (typically main)
+            - [ ] The code is well-designed.
+            - [ ] The functionality is good for the users of the code.
+            - [ ] Any User Interface changes are sensible and look good.
+            - [ ] The code isn’t more complex than it needs to be.
+            - [ ] Code coverage remains high, indicating the new code is tested.
+            - [ ] The developer used clear names for everything.
+            - [ ] Comments are clear and useful, and mostly explain why instead of what.
+            - [ ] Code is appropriately documented (doxygen and roxygen).
+            `
+            const { issue: { number: issue_number }, repo: { owner, repo }  } = context;
+            github.issues.createComment({ issue_number, owner, repo, body: msg });


### PR DESCRIPTION
@Schiano-NOAA and @sbreitbart-NOAA, This PR adds a few issue templates from FIMS to this repo. The goal is to provide instructions for anyone submitting an issue or PR, as well as for those reviewing pull requests. Please let me know if any of the templates or checklists seem excessive for this repo.

- add bug report template
- add feature request template
- add question template
- add pull request template
- add PR checklist