### PR TITLE
fix: updated syntax for cover USDC logo

### DIFF
--- a/inst/resources/formatting_files/_titlepage.tex
+++ b/inst/resources/formatting_files/_titlepage.tex
@@ -107,7 +107,7 @@ $endfor$
 \vspace{1\baselineskip}
 
 %%%%%% Tagline at bottom
-\includegraphics[artifact][width=2cm]{support_files/us_doc_logo.png}\newline
+\includegraphics[alt={},width=2cm]{support_files/us_doc_logo.png}\newline % empty curly brackets without alt text is suitable for this logo because it's purely decorative/an "artifact"
 U.S. Department of Commerce\newline
 National Oceanic and Atmospheric Administration\newline
 National Marine Fisheries Service\newline


### PR DESCRIPTION
# What is the feature?
* Fixing the cover's USDC logo to properly contain no alt text. My last commit wasn't written properly. There shouldn't be alt text for this logo because it's purely decorative (an "artifact").

# How have you implemented the solution?
* Updated (corrected) latex syntax

# Does the PR impact any other area of the project, maybe another repo?
* No
