### PR TITLE
fix(cover image)

### DIFF
--- a/R/create_template.R
+++ b/R/create_template.R
@@ -628,11 +628,10 @@ create_template <- function(
       if (add_image) {
         # extract image name
         new_img <- sapply(strsplit(spp_image, "/"), utils::tail, 1)
-
         yaml <- paste0(
           yaml,
           # image as pulled in from above
-          "cover: ", new_img, "\n"
+          "cover: support_files/", new_img, "\n"
         )
       } else if (spp_image == "") {
         yaml <- paste0(

--- a/R/utils_tex.R
+++ b/R/utils_tex.R
@@ -23,7 +23,7 @@ create_titlepage_tex <- function(office = "",
   # Add alt text to cover page image
   line_before <- grep("\\$if\\(cover)\\$", lines)
   cp_alt <- paste(
-    "\\pdftooltip{\\includegraphics{$cover$}}{",
+    "\\pdftooltip{\\includegraphics[width=6in]{$cover$}}{",
     "An illustration of ", species,
     "}",
     sep = ""


### PR DESCRIPTION
* Standardizes the size of the cover image
* adjusts spp_image argument so users can add a path to the image and it uses it properly #62

<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
*add spp image that is outside of the template

# How have you implemented the solution?
*copy image file to working folder and extract image file name

# Does the PR impact any other area of the project, maybe another repo?
*no
