### PR TITLE
fix to incorrect reference in .bib file

### DIFF
--- a/inst/resources/asar_references.bib
+++ b/inst/resources/asar_references.bib
@@ -742,8 +742,9 @@
 }
 
 @techreport{rogers_species_2003,
-  title = {Species allocation of \textit{{Sebastes}} and \textit{{Sebastolobus}} species caught by foreign countries off {Washington}, {Oregon}, and {California}, {U}.{S}.{A}. in 1965-1976},
-  institution = {Unpublished document},
+  title = {Species allocation of \textit{{Sebastes}} and \textit{{Sebastolobus}} sp. caught by foreign countries off {Washington}, {Oregon}, and {California}, {U}.{S}.{A}. in 1965-1976},
+  number = {NMFS-NWFSC-57},
+  type = {NOAA Technical Memorandum},
   author = {Rogers, J.B.},
   year = {2003}
 }

--- a/inst/resources/asar_references.bib
+++ b/inst/resources/asar_references.bib
@@ -746,7 +746,8 @@
   number = {NMFS-NWFSC-57},
   type = {NOAA Technical Memorandum},
   author = {Rogers, J.B.},
-  year = {2003}
+  year = {2003},
+  url = {https://repository.library.noaa.gov/view/noaa/3364}
 }
 
 @article{seeb_genetic_1988,


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Fixes an incorrect reference in asar_references.bib. Sorry if this PR is to the wrong branch or you prefer a different process to edit the .bib file.

# How have you implemented the solution?
* I copied info from source URL which @okenk and @chantelwetzel-noaa tracked down. This matters more than you would expect because the document is a key data source that we have not consistently included in production assessments. Having an accurate reference will improve access to the report and make it more likely that all catch is accounted for.

# Does the PR impact any other area of the project, maybe another repo?
* Definitely not.
