### PR TITLE
Fix(create_template)

### DIFF
--- a/R/create_template.R
+++ b/R/create_template.R
@@ -104,8 +104,8 @@
 #' figures, tables, alt text, and captions with `satf`, rda_dir represents
 #' the location of the folder containing these .rda files ("rda_files").
 #' Otherwise, if the user has not used `satf` to make those .rda files already,
-#' those files will be generated automatically and placed within the "report"
-#' folder within the `file_dir`. The "rda_files" folder would have been
+#' those files will be generated automatically and placed within an "rda_files"
+#' folder within rda_dir. The "rda_files" folder would have been
 #' made with `satf::exp_all_figs_tables()`, or by exporting files by running individual
 #' `satf` figure- and table-generating functions. If you have used `satf` to
 #' generate these .rda files, you can leave the arguments below blank. NOTE:
@@ -515,7 +515,7 @@ create_template <- function(
                 n_projected_years = n_projected_years,
                 relative = relative,
                 # make_rda = TRUE,
-                rda_dir = subdir,
+                rda_dir = rda_dir,
                 ref_line = ref_line,
                 ref_point = ref_point,
                 landings_unit_label = landings_unit_label,
@@ -556,13 +556,6 @@ create_template <- function(
               subdir = subdir,
               rda_dir = rda_dir
             )
-            # if there isn't an existing folder with "rda_files" in the rda_dir,
-            # and the rda_files will be placed in the subdir:
-          } else {
-            create_tables_doc(
-              subdir = subdir,
-              rda_dir = rda_dir
-            )
           }
         } else {
           tables_doc <- paste0(
@@ -596,13 +589,6 @@ create_template <- function(
             create_figures_doc(
               subdir = subdir,
               rda_dir = rda_dir
-            )
-            # if there isn't an existing folder with "rda_files" in the rda_dir,
-            # and the rda_files will be placed in the subdir:
-          } else {
-            create_figures_doc(
-              subdir = subdir,
-              rda_dir = subdir
             )
           }
         } else {

--- a/man/create_figures_doc.Rd
+++ b/man/create_figures_doc.Rd
@@ -16,8 +16,8 @@ figures for a stock assessment report. Default is true.}
 figures, tables, alt text, and captions with \code{satf}, rda_dir represents
 the location of the folder containing these .rda files ("rda_files").
 Otherwise, if the user has not used \code{satf} to make those .rda files already,
-those files will be generated automatically and placed within the "report"
-folder within the \code{file_dir}. The "rda_files" folder would have been
+those files will be generated automatically and placed within an "rda_files"
+folder within rda_dir. The "rda_files" folder would have been
 made with \code{satf::exp_all_figs_tables()}, or by exporting files by running individual
 \code{satf} figure- and table-generating functions. If you have used \code{satf} to
 generate these .rda files, you can leave the arguments below blank. NOTE:

--- a/man/create_tables_doc.Rd
+++ b/man/create_tables_doc.Rd
@@ -15,8 +15,8 @@ create_tables_doc(subdir = NULL, include_all = TRUE, rda_dir = NULL)
 figures, tables, alt text, and captions with \code{satf}, rda_dir represents
 the location of the folder containing these .rda files ("rda_files").
 Otherwise, if the user has not used \code{satf} to make those .rda files already,
-those files will be generated automatically and placed within the "report"
-folder within the \code{file_dir}. The "rda_files" folder would have been
+those files will be generated automatically and placed within an "rda_files"
+folder within rda_dir. The "rda_files" folder would have been
 made with \code{satf::exp_all_figs_tables()}, or by exporting files by running individual
 \code{satf} figure- and table-generating functions. If you have used \code{satf} to
 generate these .rda files, you can leave the arguments below blank. NOTE:

--- a/man/create_template.Rd
+++ b/man/create_template.Rd
@@ -191,8 +191,8 @@ the report}
 figures, tables, alt text, and captions with \code{satf}, rda_dir represents
 the location of the folder containing these .rda files ("rda_files").
 Otherwise, if the user has not used \code{satf} to make those .rda files already,
-those files will be generated automatically and placed within the "report"
-folder within the \code{file_dir}. The "rda_files" folder would have been
+those files will be generated automatically and placed within an "rda_files"
+folder within rda_dir. The "rda_files" folder would have been
 made with \code{satf::exp_all_figs_tables()}, or by exporting files by running individual
 \code{satf} figure- and table-generating functions. If you have used \code{satf} to
 generate these .rda files, you can leave the arguments below blank. NOTE:


### PR DESCRIPTION
# The impetus
- https://github.com/nmfs-ost/asar/issues/144

# What is the feature?
- Fix `create_template` so that rda files can be added as input, if already created, OR generated if model results are included as an argument.
- Update documentation

# How have you implemented the solution?
* in `create_template`, changed the `exp_all_figs_tables()` rda_dir argument from subdir to rda_dir. This changes the workflow so that the rda_files folder is always placed in rda_dir, not in the report folder. The issue was that the captions_alt_text.csv file was always being created in rda_dir, but `exp_all_figs_tables()` within `create_template()` was breaking because captions_alt_text.csv wasn't ever within the "report" folder. I chose to keep the rda_files folder in the rda_dir, instead of the report folder, because sometimes the user will be providing their own rda_files folder, and I wanted to keep the workflow consistent among users that did and did not provide their own rda_files folder.
* altered `create_tables/figures_doc()` calls in `create_template` so that rda_dir is always rda_dir (updated to match the change that the rda_files folder is always placed in rda_dir, not in the report folder.)

# Does the PR impact any other area of the project, maybe another repo?
* `create_tables_doc()` & `create_figures_doc()` calls in `create_template`

# Tested?
* Tested with:
  * an SS3 model result csv
  * BAM model result csv
  * empty `create_template()` call
  * a `create_template` call with convert_output = T and model_results = Report.sso
