### PR TITLE
Fix bug with references rendered in wrong location

### DIFF
--- a/R/create_template.R
+++ b/R/create_template.R
@@ -579,7 +579,7 @@ create_template <- function(
           }
         } else {
           tables_doc <- paste0(
-            "### Tables \n \n",
+            "## Tables \n \n",
             "Please refer to the `stockplotr` package downloaded from remotes::install_github('nmfs-ost/stockplotr') to add premade tables."
           )
           utils::capture.output(cat(tables_doc), file = fs::path(subdir, "08_tables.qmd"), append = FALSE)
@@ -613,7 +613,7 @@ create_template <- function(
           }
         } else {
           figures_doc <- paste0(
-            "### Figures \n \n",
+            "## Figures \n \n",
             "Please refer to the `stockplotr` package downloaded from remotes::install_github('nmfs-ost/stockplotr') to add premade figures."
           )
           utils::capture.output(cat(figures_doc), file = fs::path(subdir, "09_figures.qmd"), append = FALSE)

--- a/inst/resources/asar_references.bib
+++ b/inst/resources/asar_references.bib
@@ -1,4 +1,12 @@
 
+@Manual{asar_2025,
+  title = {asar: Build NOAA Stock Assessment Report},
+  author = {Samantha Schiano and Sophie Breitbart and Steve Saul},
+  year = {2025},
+  note = {R package version 1.0.0},
+  url = {https://github.com/nmfs-ost/asar},
+}
+
 @article{methot_stock_2013,
   title = {Stock synthesis: a biological and statistical framework for fish stock assessment and fishery management},
   volume = {142},
@@ -2190,7 +2198,7 @@ pages = {315--324},
 }
 
 @Article{Anderson:2022:SRP,
-  title = {{sdmTMB}: an R package for fast, flexible, and user-friendly generalized linear mixed effects models with spatial and spatiotemporal random fields}, 
+  title = {{sdmTMB}: an R package for fast, flexible, and user-friendly generalized linear mixed effects models with spatial and spatiotemporal random fields},
   author = {Sean C. Anderson and Eric J. Ward and and Philina A. English and Lewis A. K. Barnett},
   journal = {bioRxiv},
   year = {2022},

--- a/inst/templates/skeleton/06_acknowledgments.qmd
+++ b/inst/templates/skeleton/06_acknowledgments.qmd
@@ -4,4 +4,4 @@
 
 <!--- Please leave in the following: --->
 
-This document was produced using the @asar_2025 R package freely available on GitHub. The tool was built as a contribution to open science and the developers actively encourage modifications and suggestions to it.
+This document was produced using the @asar_2025 R package, which is free to use and publicly available on GitHub.

--- a/inst/templates/skeleton/06_acknowledgments.qmd
+++ b/inst/templates/skeleton/06_acknowledgments.qmd
@@ -1,1 +1,7 @@
 ## Acknowledgements {#sec-acknowledgements}
+
+
+
+<!--- Please leave in the following: --->
+
+This document was produced using the @asar_2025 R package freely available on GitHub. The tool was built as a contribution to open science and the developers actively encourage modifications and suggestions to it.

--- a/inst/templates/skeleton/07_references.qmd
+++ b/inst/templates/skeleton/07_references.qmd
@@ -1,6 +1,4 @@
 ## References {#sec-refs}
 
-<!---
 ::: {#refs} 
 :::
---->


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* References are placed in their proper section
* new citation in bibliography for {asar}
* acknowledgement for use of {asar} in respective section

**Intended to be placed into main as a hotfix rather than with a new feature**

# How have you implemented the solution?
* Uncomment placement notation in references.qmd
* added new citation to .bib file
* added new statement line to acknowledgements.qmd

# Does the PR impact any other area of the project, maybe another repo?
*no
