### PR TITLE
Add clarifying message before create_template() runs exp_all_figs_tables()

### DIFF
--- a/R/create_template.R
+++ b/R/create_template.R
@@ -536,6 +536,9 @@ create_template <- function(
           # test_exp_all <-
           tryCatch(
             {
+              message("Creating .rda files by running stockplotr::exp_all_figs_tables().")
+              message("This function calls two stockplotr functions- write_captions() & add_more_key_quants()- which produce the following messages about key quantities.")
+              message("-------------------")
               stockplotr::exp_all_figs_tables(
                 dat = output,
                 recruitment_scale_amount = recruitment_scale_amount,


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Adding message before exp_all_figs_tables() is run in create_template() as per Sam's request https://github.com/nmfs-ost/stockplotr/pull/70#issuecomment-2770355794

# How have you implemented the solution?
* Messages

# Does the PR impact any other area of the project, maybe another repo?
* No
