### PR TITLE
Add notation for appendix rendering

### DIFF
--- a/inst/templates/skeleton/11_appendix.qmd
+++ b/inst/templates/skeleton/11_appendix.qmd
@@ -1,1 +1,5 @@
+\appendix
+\setcounter{figure}{0}
+\setcounter{table}{0}
+
 ## Appendices {#sec-appendix}


### PR DESCRIPTION
update(appendix): change notation before section so it starts as A. B, ect instead of 11. appendix, restarts numbering of tables and figures

<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Number appendix rather than add it as additional number in outline
* reset numbering of tables and figure

# How have you implemented the solution?
* add latex code before appendix section

# Does the PR impact any other area of the project, maybe another repo?
* no
