### PR TITLE
Fix issue with add_alttext

### DIFF
--- a/R/add_alttext.r
+++ b/R/add_alttext.r
@@ -164,8 +164,9 @@ add_alttext <- function(
   obj_files <- list.files(file.path(rda_dir, "rda_files"))
 
   # read all files in obj_files and put into list
+  figures_list <- grep("figure", obj_files)
   alt_text_list <- list()
-  for (i in seq_along(obj_files)) {
+  for (i in figures_list) {
     load(file.path(rda_dir, "rda_files", obj_files[i]))
     # extract name to add into the list for placement
     rda_name <- stringr::str_replace(obj_files[i], "_figure.rda", "")


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* fix(add_alttext): only add alttext for figures in loop for fxn

# How have you implemented the solution?
* reduced objects that are run through the loop

# Does the PR impact any other area of the project, maybe another repo?
* no
