### PR TITLE
Fix issue when rerendering and adding author creates invalid spacing in yaml

### DIFF
--- a/R/create_template.R
+++ b/R/create_template.R
@@ -800,20 +800,21 @@ create_template <- function(
             aff <- affil |>
               dplyr::filter(affiliation == auth$office)
             if (is.na(auth$office)) {
-              paste0(
+              paste(
                 "  ", "- name: ", "'", auth$name, "'", "\n",
-                "  ", "  ", "affiliations: ", "NO AFFILIATION", "\n"
+                "  ", "  ", "affiliations: ", "NO AFFILIATION", "\n",
+                sep = ""
               ) -> author_list[[i]]
             } else {
-              paste0(
+              paste(
                 "  ", "- name: ", "'", auth$name, "'", "\n",
                 "  ", "  ", "affiliations:", "\n",
                 "  ", "  ", "  ", "- name: ", "'", aff$name, "'", "\n", # "NOAA Fisheries ",
                 "  ", "  ", "  ", "  ", "address: ", "'", aff$address, "'", "\n",
                 "  ", "  ", "  ", "  ", "city: ", "'", aff$city, "'", "\n",
                 "  ", "  ", "  ", "  ", "state: ", "'", aff$state, "'", "\n",
-                "  ", "  ", "  ", "  ", "postal-code: ", "'", aff$postal.code, "'", "\n"
-                # sep = " "
+                "  ", "  ", "  ", "  ", "postal-code: ", "'", aff$postal.code, "'", "\n",
+                sep = ""
               ) -> author_list[[i]]
             }
           }

--- a/R/create_yaml.R
+++ b/R/create_yaml.R
@@ -60,7 +60,7 @@ create_yaml <- function(
       #   toad <- paste(author_list[[i]], sep = ",")
       #   add_authors <- paste0(add_authors, toad) # -> add_authors
       # }
-      add_authors <- unlist(stringr::str_split(author_list, "\n "))
+      add_authors <- unlist(stringr::str_split(author_list, "\n"))
       # remove trailing \n from each author entry
       add_authors <- gsub("\n", "", add_authors)
       # check if the template was blank before


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* fix(create_yaml): authorship formatting messed up when rerender=TRUE

# How have you implemented the solution?
* Removed trailing space in extraction code of authorship in create_yaml
* removed separating space in create_template authorship section

# Does the PR impact any other area of the project, maybe another repo?
* no
