### PR TITLE
Fix issue page break rendering before citation

### DIFF
--- a/R/create_template.R
+++ b/R/create_template.R
@@ -1057,7 +1057,7 @@ create_template <- function(
       if (rerender_skeleton) {
         if (!is.null(title) | !is.null(species) | !is.null(year) | !is.null(author)) {
           citation_line <- grep("Please cite this publication as:", prev_skeleton) + 2
-          citation <- glue::glue("{{< pagebreak >}} \n\n Please cite this publication as: \n\n {prev_skeleton[citation_line]}\n\n")
+          citation <- paste("{{< pagebreak >}} \n\n Please cite this publication as: \n\n", prev_skeleton[citation_line], "\n\n")
         } else {
           author <- grep("  - name: ", prev_skeleton)
           citation <- create_citation(


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* see title
* hotfix(citation): fix bad notation before pagebreak causing the notation to render as text

# How have you implemented the solution?
* change glue to paste

# Does the PR impact any other area of the project, maybe another repo?
* no
