### PR TITLE
Proceed with rerender_skeleton if session is not interactive

### DIFF
--- a/R/create_template.R
+++ b/R/create_template.R
@@ -525,6 +525,11 @@ create_template <- function(
           warning("There are files in this location.")
           question1 <- readline("The function wants to overwrite the files currently in your directory. Would you like to proceed? (Y/N)")
 
+          # answer question1 as y if session isn't interactive
+          if (!interactive()){
+            question1 <- "y"
+          }
+
           if (regexpr(question1, "y", ignore.case = TRUE) == 1) {
             # remove old skeleton if present
             if (any(grepl("_skeleton.qmd", list.files(subdir)))) {
@@ -1010,6 +1015,11 @@ create_template <- function(
       # extract old preamble if don't want to change
       if (rerender_skeleton) {
         question1 <- readline("Do you want to keep the current preamble? (Y/N)")
+
+        # answer question1 as y if session isn't interactive
+        if (!interactive()){
+          question1 <- "y"
+        }
         if (regexpr(question1, "y", ignore.case = TRUE) == 1) {
           start_line <- grep("output_and_quantities", prev_skeleton) - 1
           # find next trailing "```"` in case it was edited at the end
@@ -1219,6 +1229,12 @@ create_template <- function(
     # Delete old skeleton
     if (length(grep("skeleton.qmd", list.files(file_dir, pattern = "skeleton.qmd"))) > 1) {
       question1 <- readline("Deleting previous skeleton file...Do you want to proceed? (Y/N)")
+
+      # answer question1 as y if session isn't interactive
+      if (!interactive()){
+        question1 <- "y"
+      }
+
       if (regexpr(question1, "y", ignore.case = TRUE) == 1) {
         file.remove(file.path(file_dir, report_name))
       } else if (regexpr(question1, "n", ignore.case = TRUE) == 1) {

--- a/tests/testthat/test-ID_tbl_width_class.R
+++ b/tests/testthat/test-ID_tbl_width_class.R
@@ -28,7 +28,7 @@ test_that("Table widths calculated correctly", {
   expect_equal(tbl_width, expected_output)
 
 
-  # regular width
+  # wide width
   stockplotr::table_bnc(dat,
                             make_rda = TRUE,
                             rda_dir = getwd())
@@ -39,7 +39,7 @@ test_that("Table widths calculated correctly", {
     portrait_pg_width = 5
   )
 
-  expected_output <- "regular"
+  expected_output <- "wide"
   expect_equal(tbl_width2, expected_output)
 
   # erase temporary testing files


### PR DESCRIPTION


# What is the feature?
* Proceed with rerender_skeleton if session is not interactive, as per https://github.com/nmfs-ost/asar/issues/205

# How have you implemented the solution?
* Test if session is interactive. If not, question1 = "y"

# Does the PR impact any other area of the project, maybe another repo?
* No
