### PR TITLE
Fix issue with create_citation and multiple matches to last name

### DIFF
--- a/R/create_citation.R
+++ b/R/create_citation.R
@@ -41,7 +41,7 @@ create_citation <- function(
       # Check and fix if there is more than one author with the same last name
       if (nrow(primauth_loc) > 1) {
         primauth_loc <- utils::read.csv(system.file("resources", "authorship.csv", package = "asar", mustWork = TRUE)) |>
-          dplyr::filter(last == unlist(strsplit(author[1], " "))[1])
+          dplyr::filter(first == unlist(strsplit(author[1], " "))[1])
       }
 
       office_loc <- utils::read.csv(system.file("resources", "affiliation_info.csv", package = "asar", mustWork = TRUE)) |>


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Fixed issue where when there is more than one author last name match in the data base, the code breaks

# How have you implemented the solution?
* Fixed the error in the code
* implemented a fail safe so the author is still added

# Does the PR impact any other area of the project, maybe another repo?
* no
