### PR TITLE
Fix author affiliation in title page

### DIFF
--- a/R/create_template.R
+++ b/R/create_template.R
@@ -826,7 +826,8 @@ create_template <- function(
                 "  ", "  ", "affiliations:", "\n",
                 "  ", "  ", "  ", "- name: ", "'", aff$name, "'", "\n", # "NOAA Fisheries ",
                 "  ", "  ", "  ", "  ", "address: ", "'", aff$address, "'", "\n",
-                "  ", "  ", "  ", "  ", "city: ", "'", aff$city, "'", "\n",
+                # TODO: remove state in the following line when notation is changed in _titlepage.tex
+                "  ", "  ", "  ", "  ", "city: ", "'", aff$city, ", ", aff$state, "'", "\n",
                 "  ", "  ", "  ", "  ", "state: ", "'", aff$state, "'", "\n",
                 "  ", "  ", "  ", "  ", "postal-code: ", "'", aff$postal.code, "'", "\n",
                 sep = ""

--- a/inst/resources/formatting_files/_titlepage.tex
+++ b/inst/resources/formatting_files/_titlepage.tex
@@ -96,7 +96,8 @@ $endif$%
 $if(by-affiliation.address)$%
 % Ross recommends putting address on one line
 $if(by-affiliation.name)$, $else$$if(by-affiliation.department)$, $endif$$endif$%
-{$it.address$}%
+% {$it.address$}%
+{$it.address$, $it.city$, $it.postal-code$}%
 $endif$%
 $sep$\par\hangindent=1em\hangafter=1%
 $endfor$


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Combines city and state in the title page so it renders - temporary fix since we will be altering authorship approach soon anyway

# How have you implemented the solution?
* new notation in _titlepage.tex and change to authorship portion in create_template

# Does the PR impact any other area of the project, maybe another repo?
* no
