### PR TITLE
Add quarto dependency to 2 github actions

### DIFF
--- a/.github/workflows/call-calc-cov-summaries.yml
+++ b/.github/workflows/call-calc-cov-summaries.yml
@@ -18,3 +18,5 @@ on:
 jobs:
   call-workflow:
     uses: nmfs-ost/ghactions4r/.github/workflows/calc-cov-summaries.yml@main
+    with:
+      depends_on_quarto: true

--- a/.github/workflows/call-calc-cov-summaries.yml
+++ b/.github/workflows/call-calc-cov-summaries.yml
@@ -15,6 +15,7 @@ on:
       - opened
     branches:
       - main
+      - dev
 jobs:
   call-workflow:
     uses: nmfs-ost/ghactions4r/.github/workflows/calc-cov-summaries.yml@main

--- a/.github/workflows/call-create-cov-badge.yml
+++ b/.github/workflows/call-create-cov-badge.yml
@@ -12,3 +12,5 @@ on:
 jobs:
   call-workflow:
     uses: nmfs-ost/ghactions4r/.github/workflows/create-cov-badge.yml@main
+    with:
+      depends_on_quarto: true


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* See #235. Adds quarto to 2 coverage github actions, but fixes the mistake I made in #235 of doing my work off of main instead of dev!
* Also adds a build trigger so that code coverage summaries will show up on pull requests made to dev (there should be an example on this PR shortly!)

# How have you implemented the solution?
*

# Does the PR impact any other area of the project, maybe another repo?
*
