### PR TITLE
Add params chunk to outlne

### DIFF
--- a/R/create_template.R
+++ b/R/create_template.R
@@ -644,6 +644,20 @@ create_template <- function(
 
       if (!rerender_skeleton) cli::cli_alert_success("Built YAML header.")
 
+      ##### Params chunk ----
+      params_chunk <- add_chunk(
+        paste0(
+          "# Parameters \n",
+          "spp <- params$species \n",
+          "SPP <- params$spp \n",
+          "species <- params$species \n",
+          "spp_latin <- params$spp_latin \n",
+          "office <- params$office"
+        ),
+        label = "doc_parameters"
+      )
+      
+      ##### Preamble ----
       # Add preamble
       # add in quantities and output data R chunk
       # Reassign model_results as output and save into environment for user
@@ -953,7 +967,8 @@ create_template <- function(
     ###### Pull together skeleton ----
     report_template <- paste(
       yaml,
-      preamble, "\n",
+      params_chunk,
+      preamble,
       disclaimer,
       citation,
       sections,


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Translate the parameters loaded in the yaml to a chunk for shorter in-text references for the user

# How have you implemented the solution?
* added new chunk to the outline with parameters loaded as objects

# Does the PR impact any other area of the project, maybe another repo?
* no
