### PR TITLE
Allow for relative paths in create_tables_doc and create_figures_doc

### DIFF
--- a/R/create_figures_doc.R
+++ b/R/create_figures_doc.R
@@ -23,7 +23,7 @@ create_figures_doc <- function(subdir = getwd(),
   # add chunk that creates object as the directory of all rdas
   figures_doc_setup <- paste0(
     add_chunk(
-      paste0("figures_dir <- '", figures_dir, "/figures'"),
+      glue::glue("figures_dir <- fs::path({deparse(substitute(figures_dir))}, 'figures')"),
       label = "set-rda-dir-figs"
     ),
     "\n"

--- a/R/create_tables_doc.R
+++ b/R/create_tables_doc.R
@@ -49,9 +49,14 @@ create_tables_doc <- function(subdir = getwd(),
     tables_doc_header <- paste0("# Tables {#sec-tables}\n \n")
 
     # add chunk that creates object as the directory of all rdas
+    # deparse(substitute()) keeps paths as strings and allows for tables_dir to
+    # become a relative filepath in the 08_tables.qmd
     tables_doc_setup <- paste0(
       add_chunk(
-        glue::glue("library(flextable)\ntables_dir <- '{tables_dir}/tables'"),
+        glue::glue(
+          "library(flextable)
+          tables_dir <- fs::path({deparse(substitute(tables_dir))}, 'tables')"
+          ),
         label = "set-rda-dir-tbls",
         # add_option = TRUE,
         chunk_option = c(


### PR DESCRIPTION


<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Allow for relative paths in create_tables_doc and create_figures_doc

# How have you implemented the solution?
* using `deparse(substitute())` to parse path

# Does the PR impact any other area of the project, maybe another repo?
* No