### PR TITLE
Remove latex warnings on tagging

### DIFF
--- a/R/add_tagging.r
+++ b/R/add_tagging.r
@@ -72,6 +72,13 @@ add_tagging <- function(
       tex_file[issue_color]
     )
   }
+  # Comment out microtype package
+  microtype_line1 <- grep("\\IfFileExists\\{microtype.sty\\}\\{\\% use microtype if available", tex_file)
+  microtype_chunk <- paste0(
+    "% ", tex_file[microtype_line1:(microtype_line1 + 3)]
+  )
+  tex_file[microtype_line1:(microtype_line1 + 3)] <- microtype_chunk
+  
   # Export file
   write(tex_file, file = file.path(dir, ifelse(!is.null(rename), glue::glue("{rename}.tex"), x)))
 

--- a/R/utils_tex.R
+++ b/R/utils_tex.R
@@ -97,6 +97,11 @@ create_inheader_tex <- function(species = NULL, year = NULL, subdir) {
     lines <- append(lines, to_add)
   }
 
+  # add soul package directly so error goes away
+  lines <- append(
+    lines,
+    "% add soul package to remove latex error\n\\usepackage{soul}\n",
+  )
   # Add in notation to add glossary
   # Notation permenantly added in the initial in-header.tex doc
   # gloss <- paste(

--- a/inst/resources/formatting_files/in-header.tex
+++ b/inst/resources/formatting_files/in-header.tex
@@ -20,7 +20,7 @@
 \makenoidxglossaries
 \loadglsentries{report_glossary.tex}
 
-\usepackage{lmodern}
+% \usepackage{lmodern}
 \usepackage[T1]{fontenc}
 
 \newfontfamily\sectionfont[Color=Black]{Latin Modern Sans}


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Remove latex warning when tagging document

# How have you implemented the solution?
* removed notation for one package that gets loaded in from quarto
* add in soul package

# Does the PR impact any other area of the project, maybe another repo?
* no
