### PR TITLE
Move default figures/tables doc content to respective functions

### DIFF
--- a/R/create_figures_doc.R
+++ b/R/create_figures_doc.R
@@ -1,8 +1,8 @@
 #' Create Quarto Document of Figures
 #'
+#' @param subdir Location of subdirectory storing the assessment report template
 #' @param figures_dir The location of the "figures" folder, which contains
 #' figures files.
-#' @param subdir Location of subdirectory storing the assessment report template
 #'
 #' @return A quarto document with pre-loaded R chunk that adds the
 #' stock assessment tables from the nmfs-ost/stockplotr R package. The
@@ -33,13 +33,11 @@ create_figures_doc <- function(subdir = getwd(),
 
   # list all files in figures
   file_list <- list.files(file.path(figures_dir, "figures"))
-  # create sublist of only figure files
-  file_fig_list <- file_list[grepl("_figure", file_list)]
 
   # create sublist of only rda figure files
-  rda_fig_list <- file_fig_list[grepl("_figure.rda", file_fig_list)]
+  rda_fig_list <- file_list[grepl("_figure.rda", file_list)]
   # create sublist of only non-rda figure files
-  non.rda_fig_list <- file_fig_list[!grepl(".rda", file_fig_list)]
+  non.rda_fig_list <- file_list[!grepl(".rda", file_list)]
 
   # create two-chunk system to plot each rda figure
   create_fig_chunks <- function(fig = NA,
@@ -94,11 +92,19 @@ rm(rda)\n
     ))
   }
 
-  if (length(file_fig_list) == 0) {
+  if (length(file_list) == 0) {
     cli::cli_alert_warning("Found zero figure files in {fs::path(figures_dir, 'figures')}.",
       wrap = TRUE
     )
-    figures_doc <- "# Figures {#sec-figures}"
+    cli::cli_alert_info("For `create_figures_doc` to run properly, there must be:",
+      wrap = TRUE)
+    cli::cli_ol(c("a 'figures' folder in {fs::path(figures_dir)}",
+                  "files in appropriate formats (e.g., .rda, .png, .jpg) in the 'figures' folder")
+    )
+    figures_doc <- paste0(
+      "# Figures {#sec-figures}\n\n",
+      "Please refer to the `stockplotr` package downloaded from remotes::install_github('nmfs-ost/stockplotr') to add premade figures."
+    )
   } else {
     # paste rda figure code chunks into one object
     if (length(rda_fig_list) > 0) {

--- a/R/create_tables_doc.R
+++ b/R/create_tables_doc.R
@@ -14,9 +14,9 @@
 #' share the same caption. To specify a different repeated column(s), use
 #' asar::export_split_tbls with your preferred essential_columns value.
 #'
+#' @inheritParams create_figures_doc
 #' @param tables_dir The location of the "tables" folder, which contains tables
 #' files.
-#' @inheritParams create_figures_doc
 #'
 #' @return Create a quarto document as part of a stock assessment outline with
 #' pre-loaded R chunks that add stock assessment tables from the nmfs-ost/stockplotr
@@ -249,7 +249,13 @@ load(file.path(tables_dir, '", stringr::str_remove(tab, "_split"), "'))\n
     cli::cli_alert_warning("Found zero tables in an rda format (i.e., .rda) in {fs::path(tables_dir, 'tables')}.",
       wrap = TRUE
     )
-    tables_doc <- "# Tables {#sec-tables}"
+    cli::cli_alert_info("For `create_tables_doc` to run properly, there must be:",
+                        wrap = TRUE)
+    cli::cli_ol(c("a 'tables' folder in {fs::path(tables_dir)}",
+                  ".rda files in the 'tables' folder")
+    )
+    tables_doc <- paste0("# Tables {#sec-tables}\n\n",
+                         "Please refer to the `stockplotr` package downloaded from remotes::install_github('nmfs-ost/stockplotr') to add premade tables.")
   } else {
     cli::cli_alert_success("Found {length(final_rda_tab_list)} table{?s} in an rda format (i.e., .rda) in {fs::path(tables_dir, 'tables')}.",
       wrap = TRUE

--- a/R/create_template.R
+++ b/R/create_template.R
@@ -34,6 +34,10 @@
 #' @param title A custom title that is an alternative to the default title (composed
 #' in asar::create_title()). Example: "Management Track Assessments Spring 2024".
 #' @param model_results Path to standard output file made from `asar::convert_output()`
+#' @param tables_dir The location of the "tables" folder, which contains tables
+#' files. Default is the working directory.
+#' @param figures_dir The location of the "figures" folder, which contains
+#' figures files. Default is the working directory.
 #' @param spp_image File path to the species' image if not
 #' using the image included in the project's repository.
 #' @param bib_file File path to a .bib file used for citing references in
@@ -42,10 +46,10 @@
 #' will pull the last saved stock assessment report skeleton.
 #' Default is false.
 #' @param rerender_skeleton Re-create the "skeleton.qmd" in your outline when
-#'        changes to the main skeleton need to be made. This reproduces the
-#'        yaml, output (if changed), preamble quantities, and restructures your
-#'        sectioning in the skeleton if indicated. All files in your folder
-#'        will remain as is.
+#' changes to the main skeleton need to be made. This reproduces the
+#' yaml, output (if changed), preamble quantities, and restructures your
+#' sectioning in the skeleton if indicated. All files in your folder
+#' will remain as is.
 #' @param custom TRUE/FALSE; Build custom sectioning for the
 #' template, rather than the default for stock assessments in
 #' your region? Default is false.
@@ -93,11 +97,6 @@
 #' using the image included in the project's repository.
 #' @param bib_file File path to a .bib file used for citing references in
 #' the report
-#' @param rerender_skeleton Re-create the "skeleton.qmd" in your outline when
-#'        changes to the main skeleton need to be made. This reproduces the
-#'        yaml, output (if changed), preamble quantities, and restructures your
-#'        sectioning in the skeleton if indicated. All files in your folder
-#'        will remain as is.
 #' @param ... Additional arguments passed into functions used in create_template
 #' such as `create_citation()`, `format_quarto()`, `add_chunk()`, ect
 #'
@@ -129,6 +128,8 @@
 #'     "Patrick Star" = "SEFSC-ML"
 #'   ),
 #'   model_results = here::here("folder", "std_output.rda"),
+#'   figures_dir = here::here(),
+#'   tables_dir = here::here("tables_folder_location"),
 #'   new_section = "an_additional_section",
 #'   section_location = "after-introduction"
 #' )
@@ -182,6 +183,8 @@ create_template <- function(
     file_dir = getwd(),
     title = "[TITLE]",
     model_results = NULL,
+    tables_dir = getwd(),
+    figures_dir = getwd(),
     spp_image = "",
     bib_file = "asar_references.bib",
     new_template = TRUE,
@@ -575,12 +578,14 @@ create_template <- function(
         "safe" = "11_tables.qmd",
         "08_tables.qmd"
       )
-      tables_doc <- paste0(
-        "# Tables \n \n",
-        "Please refer to the `stockplotr` package downloaded from remotes::install_github('nmfs-ost/stockplotr') to add premade tables."
-      )
-      utils::capture.output(cat(tables_doc), file = fs::path(subdir, tables_doc_name), append = FALSE)
-    }
+      tables_doc <- ""
+      utils::capture.output(cat(tables_doc), 
+                            file = fs::path(subdir, tables_doc_name), 
+                            append = FALSE)
+  
+      create_tables_doc(subdir = subdir,
+                        tables_dir = tables_dir)
+      }
 
     # Create figures qmd
     if (!rerender_skeleton) {
@@ -589,11 +594,13 @@ create_template <- function(
         "safe" = "12_figures.qmd",
         "09_figures.qmd"
       )
-      figures_doc <- paste0(
-        "# Figures \n \n",
-        "Please refer to the `stockplotr` package downloaded from remotes::install_github('nmfs-ost/stockplotr') to add premade figures."
-      )
-      utils::capture.output(cat(figures_doc), file = fs::path(subdir, figures_doc_name), append = FALSE)
+      figures_doc <- ""
+      utils::capture.output(cat(figures_doc), 
+                            file = fs::path(subdir, figures_doc_name),
+                            append = FALSE)
+      
+      create_figures_doc(subdir = subdir,
+                         figures_dir = figures_dir)
     }
 
     # Part I

--- a/man/create_template.Rd
+++ b/man/create_template.Rd
@@ -16,6 +16,8 @@ create_template(
   file_dir = getwd(),
   title = "[TITLE]",
   model_results = NULL,
+  tables_dir = getwd(),
+  figures_dir = getwd(),
   spp_image = "",
   bib_file = "asar_references.bib",
   new_template = TRUE,
@@ -71,6 +73,12 @@ by this function. Default is the working directory.}
 in asar::create_title()). Example: "Management Track Assessments Spring 2024".}
 
 \item{model_results}{Path to standard output file made from \code{asar::convert_output()}}
+
+\item{tables_dir}{The location of the "tables" folder, which contains tables
+files. Default is the working directory.}
+
+\item{figures_dir}{The location of the "figures" folder, which contains
+figures files. Default is the working directory.}
 
 \item{spp_image}{File path to the species' image if not
 using the image included in the project's repository.}
@@ -162,6 +170,8 @@ create_template(
     "Patrick Star" = "SEFSC-ML"
   ),
   model_results = here::here("folder", "std_output.rda"),
+  figures_dir = here::here(),
+  tables_dir = here::here("tables_folder_location"),
   new_section = "an_additional_section",
   section_location = "after-introduction"
 )


### PR DESCRIPTION
@Schiano-NOAA could you please make sure the reports render properly? I'm having issues rendering and am not sure if it's due to the new posit cloud setup or these changes. 

ERROR: 
compilation failed- error
Math error: parameter \Umathsup_shift_drop\textstyle is not set.
\@ensuredmath #1->$\relax #1$
                             
l.281   {\textsuperscript{1}
                          }%

# What is the feature?
* Move default figures/tables doc content to respective functions as per https://github.com/nmfs-ost/asar/issues/312
* update documentation

