### PR TITLE
[Feature]: rename the final pdf final after adding a11y

### DIFF
--- a/R/add_accessibility.R
+++ b/R/add_accessibility.R
@@ -72,14 +72,8 @@ add_accessibility <- function(
     x = ifelse(is.null(rename), x, glue::glue("{rename}.tex")),
     dir = dir,
     figures_dir = figures_dir,
-    compile = FALSE,
+    compile = compile,
     rename = rename,
     alttext_csv_dir = figures_dir
   )
-  # Render the .tex file after edits
-  if (compile) {
-    # message("______Tagging structure added to tex file.______")
-    # test if this can be done when skeleton is in different folder than the wd
-    tinytex::lualatex(file.path(dir, ifelse(!is.null(rename), glue::glue("{rename}.tex"), x)))
-  }
 }

--- a/R/add_alttext.r
+++ b/R/add_alttext.r
@@ -249,9 +249,24 @@ add_alttext <- function(
   cli::cli_alert_success("______Alternative text added to tex file.______")
   # Render the .tex file after edits
   if (compile) {
+    # Find name for the previously rendered report
+    prev_report_name <- list.files(dir, pattern = ".pdf")
+    if (length(prev_report_name) > 1) {
+      cli::cli_alert_info("______Multiple pdfs found in directory, defaulting to the tex file name______")
+      pdf_report_name <- NULL
+    }
+    pdf_report_name <- ifelse(is.null(rename), prev_report_name, glue::glue("{rename}.pdf"))
+    if (length(prev_report_name) == 0) {
+      cli::cli_alert_info("______No previous report found, defaulting to the tex file name______")
+      pdf_report_name <- NULL
+    }
+    # Render the report
     cli::cli_alert_info("______Compiling in progress - This can take a while...______")
     # test if this can be done when skeleton is in different folder than the wd
-    tinytex::lualatex(file.path(dir, ifelse(!is.null(rename), glue::glue("{rename}.tex"), x)))
+    tinytex::lualatex(
+      file = file.path(dir, ifelse(!is.null(rename), glue::glue("{rename}.tex"), x)),
+      pdf_file = pdf_report_name
+    )
     cli::cli_alert_success("______Compiling finished______")
   }
 }

--- a/R/add_tagging.r
+++ b/R/add_tagging.r
@@ -109,9 +109,24 @@ add_tagging <- function(
   utils::capture.output(cat(accessibility), file = file.path(dir, "accessibility.tex"), append = FALSE)
   cli::cli_alert_success("______Tagging structure added to tex file.______")
   if (compile) {
+    # Find name for the previously rendered report
+    prev_report_name <- list.files(dir, pattern = ".pdf")
+    if (length(prev_report_name) > 1) {
+      cli::cli_alert_info("______Multiple pdfs found in directory, defaulting to the tex file name______")
+      pdf_report_name <- NULL
+    }
+    pdf_report_name <- ifelse(is.null(rename), prev_report_name, glue::glue("{rename}.pdf"))
+    if (length(prev_report_name) == 0) {
+      cli::cli_alert_info("______No previous report found, defaulting to the tex file name______")
+      pdf_report_name <- NULL
+    }
+    # Render the report
     cli::cli_alert_info("______Compiling in progress - This can take a while...______")
     # test if this can be done when skeleton is in different folder than the wd
-    tinytex::lualatex(file.path(dir, ifelse(!is.null(rename), glue::glue("{rename}.tex"), x)))
+    tinytex::lualatex(
+      file = file.path(dir, ifelse(!is.null(rename), glue::glue("{rename}.tex"), x)),
+      pdf_file = pdf_report_name
+    )
     cli::cli_alert_success("______Compiling finished______")
   }
 }


### PR DESCRIPTION
…e name of the previous pdf

<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Add in the ability to keep the same name as the pdf file when rename = NULL
* This PR is complete and was done during the NSAP code cleanup

# How have you implemented the solution?
* Add new call on render at the end of the function

# Does the PR impact any other area of the project, maybe another repo?
* no
