### PR TITLE
Fix region abbreviation in report name

### DIFF
--- a/R/create_template.R
+++ b/R/create_template.R
@@ -287,7 +287,7 @@ create_template <- function(
       !is.null(region),
       paste0(
         report_name,
-        gsub("(\\b[A-Z])[^A-Z]+", "\\1", region),
+        toupper(stringr::str_c(stringr::str_extract_all(region, "\\b[A-Za-z]")[[1]], collapse = "")),
         "_"
       ),
       report_name


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Change code for add region abbreviation in the report name (GA -> GOA)

# How have you implemented the solution?
* used stringr instead of gsub

# Does the PR impact any other area of the project, maybe another repo?
*no
