### PR TITLE
Fix bug when making custom template

### DIFF
--- a/R/create_template.R
+++ b/R/create_template.R
@@ -881,13 +881,9 @@ create_template <- function(
       # Create custom template from existing skeleton sections
       if (is.null(new_section)) {
         section_list <- add_base_section(files_to_copy)
-        sections <- add_child(section_list,
-          label = custom_sections # this might need to be changed
-        )
         # Create sections object to add into template
-        sections <- add_child(
-          sections,
-          label = stringr::str_extract(unlist(sections), "(?<=_).+(?=\\.qmd$)")
+        sections <- add_child(section_list,
+          label = stringr::str_extract(unlist(section_list), "(?<=_).+(?=\\.qmd$)")
         )
       } else { # custom = TRUE
         # Create custom template using existing sections and new sections from analyst


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* remove duplicated code when custom sections are explicit causing improper formatting
* address issue #350 

# How have you implemented the solution?
* removed duplicated code in the function where custom sectioning is handled

# Does the PR impact any other area of the project, maybe another repo?
* yes, this will need to be rebased throughout all branches
