### PR TITLE
Upload action to alert stockplotr of new release

### DIFF
--- a/.github/workflows/release-for-stockplotr-update.yml
+++ b/.github/workflows/release-for-stockplotr-update.yml
@@ -1,0 +1,32 @@
+# This workflow lives in Repository A (the one with the new release)
+
+name: 1. Dispatch Release to Repo B
+
+on:
+  release:
+    # Trigger ONLY when a new release is published
+    types: [published]
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send repository_dispatch to Repository B (stockplotr)
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          # This token is required to talk to the GitHub API.
+          # It must be a PAT stored in Repo A's secrets with 'repo' scope.
+          token: ${{ secrets.REPO_B_PAT }}
+          
+          # The target repository where the action will run
+          repository: 'nmfs-ost/stockplotr' 
+          
+          # This is the event name that Repo B's workflow will listen for.
+          event-type: 'release_trigger'
+          
+          # Pass data needed by Repo B in the client-payload
+          client-payload: |
+            {
+              "release_tag": "${{ github.event.release.tag_name }}",
+              "repository_a_name": "${{ github.repository }}"
+            }


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* New github action that works in tandem with action in stockplotr to update example data

# How have you implemented the solution?
* New workflow for github action to interact with stockplotr

# Does the PR impact any other area of the project, maybe another repo?
* yes, directly interacts with stockplotr -- I am not sure of the repercussions of this action and potential issues.

@k-doering-NOAA if you have any thoughts, advice, or could provide help on this, it would be greatly appreciated!
