### PR TITLE
[feat] Add new template "type" for SEDAR reports

### DIFF
--- a/R/create_citation.R
+++ b/R/create_citation.R
@@ -19,10 +19,22 @@
 create_citation <- function(
   authors = NULL,
   title = "[TITLE]",
-  year = format(as.POSIXct(Sys.Date(), format = "%YYYY-%mm-%dd"), "%Y")
+  year = format(as.POSIXct(Sys.Date(), format = "%YYYY-%mm-%dd"), "%Y"),
+  type = NULL
 ) {
   # Check if authors is input - improved from previous fxn so did not fail
   if (is.null(authors) | any(authors == "")) {
+    if (tolower(type) == "sedar"){
+      citation <- paste0(
+        "{{< pagebreak >}} \n",
+        "\n",
+        "Please cite this publication as: \n",
+        "\n",
+        "SEDAR. ",
+        year, ". ",
+        title, ". SEDAR, North Charleston SC. \\pageref*{LastPage}{} pp."
+      )
+    } else {
     cli::cli_alert_warning("Authorship not defined.")
     cli::cli_alert_info("Did you forget to specify `authors`?")
     # Define default citation - needs authors editing
@@ -35,7 +47,7 @@ create_citation <- function(
       title, ". National Marine Fisheries Service, ",
       "[CITY], [STATE]. \\pageref*{LastPage}{} pp."
     )
-  } else {
+  } } else {
     # Authored by Kelli Johnson in previous PR
     author_data_frame <- data.frame(office = authors) |>
       tibble::rownames_to_column("input") |>
@@ -141,7 +153,7 @@ create_citation <- function(
       "\n",
       "Please cite this publication as: \n",
       "\n",
-      ifelse(primary_author_office[["office"]] == "SEFSC", "SEDAR.", author_list),
+      ifelse(primary_author_office[["office"]] == "SEFSC" | tolower(type) == "sedar", "SEDAR.", author_list),
       " ", year, ". ",
       glue::glue("{title}"), ". ",
       region_specific_part,

--- a/R/create_template.R
+++ b/R/create_template.R
@@ -16,7 +16,9 @@
 #'
 #' Default: "sar" (a NOAA standard "Stock Assessment Report")
 #'
-#' Options: "sar" (Stock Assessment Report), "nemt" (Northeast Management Track), "pfmc" (Pacific Fishery Management Council), "safe" (Stock Assessment and Fishery Evaluation)
+#' Options: "sar" (Stock Assessment Report), "nemt" (Northeast Management Track),
+#' "pfmc" (Pacific Fishery Management Council), "safe" (Stock Assessment and 
+#' Fishery Evaluation), "sedar" (SouthEast Data, Assessment, and Review)
 #'
 #' @param office Regional Fisheries Science Center producing the report.
 #'
@@ -265,21 +267,26 @@ create_template <- function(
       "Pacific Fishery Management Council" = "pfmc",
       "Stock Assessment and Fishery Evaluation" = "safe",
       "Stock Assessment Report" = "skeleton",
+      "SouthEast Data, Assessment, and Review" = "sedar",
+      "SouthEast Data Assessment and Review" = "sedar",
       "sar" = "skeleton",
       "pfmc" = "pfmc",
       "nemt" = "nemt",
       "safe" = "safe",
+      "sedar" = "sedar",
+      "SEDAR" = "sedar",
       {
         type_fxn <- function() {
           selection <- utils::menu(
             title = "Unrecognized template type. Please select an option below: ",
-            choices = c("Default", "Pacific Fisheries Management Council", "Northeast Management Track", "SAFE")
+            choices = c("Default", "Pacific Fisheries Management Council", "Northeast Management Track", "SAFE", "SEDAR")
           )
           type <- switch(as.character(selection),
             "1" = "skeleton",
             "2" = "pfmc",
             "3" = "nemt",
             "4" = "safe",
+            "5" = "sedar",
             {
               "skeleton"
             }
@@ -462,7 +469,15 @@ create_template <- function(
 
     asar_folder <- system.file("templates", package = "asar")
     # copy files from specific type folder
-    current_folder <- ifelse(rerender_skeleton, subdir, file.path(asar_folder, type))
+    if (rerender_skeleton){
+      current_folder <- subdir
+    } else {
+      current_folder <- file.path(asar_folder,
+                                  # sedar report files identical to skeleton
+                                  ifelse(type == tolower("sedar"),
+                                         "skeleton",
+                                         type))
+    }
     new_folder <- subdir
 
     ##### Identify files to copy ----

--- a/R/create_template.R
+++ b/R/create_template.R
@@ -469,15 +469,9 @@ create_template <- function(
 
     asar_folder <- system.file("templates", package = "asar")
     # copy files from specific type folder
-    if (rerender_skeleton){
-      current_folder <- subdir
-    } else {
-      current_folder <- file.path(asar_folder,
-                                  # sedar report files identical to skeleton
-                                  ifelse(type == tolower("sedar"),
-                                         "skeleton",
-                                         type))
-    }
+    current_folder <- ifelse(rerender_skeleton,
+                             subdir,
+                             file.path(asar_folder, type))
     new_folder <- subdir
 
     ##### Identify files to copy ----
@@ -1130,7 +1124,10 @@ create_template <- function(
       citation <- create_citation(
         authors = authors,
         title = title,
-        year = year
+        year = year,
+        type = ifelse(tolower(office) == "sefsc",
+                      "sedar",
+                      type)
       )
       cli::cli_alert_success("Added report citation.")
     }

--- a/R/create_yaml.R
+++ b/R/create_yaml.R
@@ -223,7 +223,7 @@ create_yaml <- function(
     
     sedar_author <- "  - name: 'SEDAR'\n    affiliations: \n        address: '4055 Faber Place Drive, Suite 201' \n        city: 'North Charleston' \n        state: 'SC' \n        postal-code: '29405' \n"
 
-    yaml <- ifelse(office == "SEFSC",
+    yaml <- ifelse(tolower(type) == "sedar",
                    paste0(yaml, sedar_author),
                    paste0(yaml, add_authors))
 

--- a/R/create_yaml.R
+++ b/R/create_yaml.R
@@ -220,7 +220,12 @@ create_yaml <- function(
       toad <- paste(author_list[[i]], sep = ",")
       add_authors <- paste0(add_authors, toad) # -> add_authors
     }
-    yaml <- paste0(yaml, add_authors)
+    
+    sedar_author <- "  - name: 'SEDAR'\n    affiliations: \n        address: '4055 Faber Place Drive, Suite 201' \n        city: 'North Charleston' \n        state: 'SC' \n        postal-code: '29405' \n"
+
+    yaml <- ifelse(type == "sedar",
+                   paste0(yaml, sedar_author),
+                   paste0(yaml, add_authors))
 
     # Add other parts
     yaml <- paste0(

--- a/R/create_yaml.R
+++ b/R/create_yaml.R
@@ -223,7 +223,7 @@ create_yaml <- function(
     
     sedar_author <- "  - name: 'SEDAR'\n    affiliations: \n        address: '4055 Faber Place Drive, Suite 201' \n        city: 'North Charleston' \n        state: 'SC' \n        postal-code: '29405' \n"
 
-    yaml <- ifelse(type == "sedar",
+    yaml <- ifelse(office == "SEFSC",
                    paste0(yaml, sedar_author),
                    paste0(yaml, add_authors))
 

--- a/inst/README.md
+++ b/inst/README.md
@@ -16,4 +16,5 @@ This folder contains various files which support the creation of materials for r
   * `preamble` R file used to extract key quantities from model results file used in asar report (`preamble.R`)
   * Images of species used for asar report cover pages (`spp_img` folder)
   * US Dept of Commerce logo placed on report title page (`us_doc_logo.png`)
-* The `templates` sub-folder contains the child documents used for each report "type": Northeast management track (nemt); Pacific Fisheries Marine Council (pfmc); Stock Assessment and Fishery Evaluation (safe); standard report format (skeleton)
+* The `templates` sub-folder contains the child documents used for each report "type": Northeast management track (nemt); Pacific Fisheries Marine Council (pfmc); Stock Assessment and Fishery Evaluation (safe); SouthEast Data, Assessment, and Review (sedar),
+standard report format (skeleton)

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -53,6 +53,7 @@ SEFSC
 SSC
 SWA
 SWFSC
+SouthEast
 Strikethrough
 TOC
 TinyTeX
@@ -119,6 +120,7 @@ roboto
 saltatrix
 sar
 se
+sedar
 snakecase
 socio
 sso

--- a/inst/templates/sedar/01_introduction.qmd
+++ b/inst/templates/sedar/01_introduction.qmd
@@ -9,7 +9,23 @@
 
 ## List of Participants
 
+```{r}
+#| label: 'tab-participants'
+#| warnings: false 
+#| eval: true
+#| tbl-cap: "Participants involved in the SEDAR workshop."
+#| tbl-pos: 't'
+
+participants <- data.frame(
+  "Appointee" = c("Example Participant", "", "", "", "", ""),
+  "Function" = c("Lead Analyst", "", "", "", "", ""),
+  "Affiliation" = c("Beaufort, NC", "", "", "", "", "")
+)
+
+gt::gt(participants)
+
+```
+
 
 ## List of Working Papers and Reference Documents
-
 

--- a/inst/templates/sedar/01_introduction.qmd
+++ b/inst/templates/sedar/01_introduction.qmd
@@ -1,0 +1,15 @@
+# Introduction {#sec-intro}
+
+
+## Workshop Time and Place
+
+
+## Terms of Reference
+
+
+## List of Participants
+
+
+## List of Working Papers and Reference Documents
+
+

--- a/inst/templates/sedar/02_data_review.qmd
+++ b/inst/templates/sedar/02_data_review.qmd
@@ -1,0 +1,68 @@
+# Data Review and Update {#sec-data}
+
+
+## Stock Structure and Management Unit
+
+
+## Life History Parameters
+
+
+### Morphometric and Conversion Factors
+
+
+### Age and Growth
+
+
+### Natural Mortality
+
+
+### Maturity
+
+
+### Sexual Transition
+
+
+### Fecundity
+
+
+### Discard Mortality
+
+
+## Fishery-Dependent Data
+
+
+### Commercial Landings
+
+
+### Recreational Landings
+
+
+### Commercial Discards
+
+
+### Recreational Discards
+
+
+### Commercial Size Composition
+
+
+### Recreational Size Composition
+
+
+### Commercial Age Composition
+
+
+### Recreational Age Composition
+
+
+### Commercial Catch Per Unit of Effort Indices of Abundance
+
+
+### Recreational Catch Per Unit of Effort Indices of Abundance
+
+
+## Fishery-Independent Surveys
+
+
+## Environmental Considerations and Contributions from Stakeholders
+

--- a/inst/templates/sedar/03_model-configuration.qmd
+++ b/inst/templates/sedar/03_model-configuration.qmd
@@ -1,0 +1,70 @@
+# Stock Assessment Model Configuration {#sec-mod-config}
+
+## Model Configuration
+
+
+### Initial Conditions
+
+
+### Temporal Structure
+
+
+### Spatial Structure
+
+
+### Life History
+
+
+### Recruitment Dynamics
+
+
+### Fleet Structure and Surveys
+
+
+### Selectivity
+
+
+### Retention
+
+
+### Landings and Associated Length and Age Compositions
+
+
+### Discards and Associated Length Compositions
+
+
+### Indices
+
+
+## Goodness of Fit and Assumed Error Structure
+
+
+## Estimated Parameters
+
+
+## Model Diagnostics
+
+
+### Residual Analysis
+
+
+### Correlation Analysis
+
+
+### Profile Likelihoods
+
+
+### Jitter Analysis
+
+
+### Retrospective Analysis
+
+
+### Jack-knife Analysis on Indices of Abundance
+
+
+### Additional Diagnostics
+
+
+## Sensitivity Runs
+

--- a/inst/templates/sedar/04_model-results.qmd
+++ b/inst/templates/sedar/04_model-results.qmd
@@ -1,0 +1,55 @@
+# Stock Assessment Model Results {#sec-model-results}
+
+## Estimated Parameters
+
+
+## Fishing Mortality
+
+
+## Selectivity
+
+
+## Recruitment
+
+
+## Biomass and Abundance Trajectories
+
+
+## Model Fit and Residual Analysis
+
+
+### Landings
+
+
+### Discards
+
+
+### Indices
+
+
+### Length Compositions
+
+
+### Age Compositions
+
+## Model Diagnostics
+
+### Correlation Analysis
+
+
+### Profile Likelihoods
+
+
+### Jitter Analysis
+
+
+### Retrospective Analysis
+
+
+### Bridging Analysis
+
+
+### Sensitivity Model Runs
+
+
+

--- a/inst/templates/sedar/05_discussion.qmd
+++ b/inst/templates/sedar/05_discussion.qmd
@@ -1,0 +1,3 @@
+# Discussion {#sec-discussion}
+
+<!--- The discussion is dependent on analyst/assessment/region. Include subsections discussing ecosystem considerations (if applicable) and research recommendations/improvements to the assessment. --->

--- a/inst/templates/sedar/06_projections.qmd
+++ b/inst/templates/sedar/06_projections.qmd
@@ -1,0 +1,21 @@
+# Projections {#sec-projections}
+
+## Introduction
+
+
+## Projection Methods
+
+
+## Projection Results
+
+
+### Biological Reference Points
+
+
+### Stock Status
+
+
+### Overfishing Limit and Acceptable Biological Catch Projections
+
+
+### Constant Catch

--- a/inst/templates/sedar/06_projections.qmd
+++ b/inst/templates/sedar/06_projections.qmd
@@ -17,5 +17,3 @@
 
 ### Overfishing Limit and Acceptable Biological Catch Projections
 
-
-### Constant Catch

--- a/inst/templates/sedar/07_acknowledgments.qmd
+++ b/inst/templates/sedar/07_acknowledgments.qmd
@@ -1,0 +1,7 @@
+# Acknowledgements {#sec-acknowledgements}
+
+
+
+<!--- Please leave in the following: --->
+
+This document was produced using the R package asar [@asar_2026], which is free to use and publicly available on [GitHub](https://github.com/nmfs-ost/asar).

--- a/inst/templates/sedar/08_references.qmd
+++ b/inst/templates/sedar/08_references.qmd
@@ -1,0 +1,4 @@
+# References {#sec-refs}
+
+::: {#refs} 
+:::

--- a/inst/templates/sedar/11_appendix.qmd
+++ b/inst/templates/sedar/11_appendix.qmd
@@ -1,0 +1,9 @@
+\appendix
+\setcounter{figure}{0}
+\setcounter{table}{0}
+
+# Appendices {#sec-appendix}
+
+<!--- 
+Any information relevant for evaluation of the stock either during SSC or management review should be included in the appendix. The main assessment document should contain the minimum necessary information to inform and provide management advice for the stock while additional materials can be found in the appendix.
+--->

--- a/man/create_citation.Rd
+++ b/man/create_citation.Rd
@@ -7,7 +7,8 @@
 create_citation(
   authors = NULL,
   title = "[TITLE]",
-  year = format(as.POSIXct(Sys.Date(), format = "\%YYYY-\%mm-\%dd"), "\%Y")
+  year = format(as.POSIXct(Sys.Date(), format = "\%YYYY-\%mm-\%dd"), "\%Y"),
+  type = NULL
 )
 }
 \arguments{
@@ -34,6 +35,14 @@ Default: \verb{[TITLE]}. If species and region are provided, a title will be gen
 \item{year}{Year the assessment is conducted.
 
 Default: the year in which the report is rendered.}
+
+\item{type}{Report template type.
+
+Default: "sar" (a NOAA standard "Stock Assessment Report")
+
+Options: "sar" (Stock Assessment Report), "nemt" (Northeast Management Track),
+"pfmc" (Pacific Fishery Management Council), "safe" (Stock Assessment and
+Fishery Evaluation), "sedar" (SouthEast Data, Assessment, and Review)}
 }
 \value{
 Generate a citation for use in publications and other

--- a/man/create_template.Rd
+++ b/man/create_template.Rd
@@ -43,7 +43,7 @@ Default: "sar" (a NOAA standard "Stock Assessment Report")
 
 Options: "sar" (Stock Assessment Report), "nemt" (Northeast Management Track),
 "pfmc" (Pacific Fishery Management Council), "safe" (Stock Assessment and
-Fishery Evaluation)}
+Fishery Evaluation), "sedar" (SouthEast Data, Assessment, and Review)}
 
 \item{office}{Regional Fisheries Science Center producing the report.
 

--- a/man/create_template.Rd
+++ b/man/create_template.Rd
@@ -41,7 +41,9 @@ Options: "pdf", "html"}
 
 Default: "sar" (a NOAA standard "Stock Assessment Report")
 
-Options: "sar" (Stock Assessment Report), "nemt" (Northeast Management Track), "pfmc" (Pacific Fishery Management Council), "safe" (Stock Assessment and Fishery Evaluation)}
+Options: "sar" (Stock Assessment Report), "nemt" (Northeast Management Track),
+"pfmc" (Pacific Fishery Management Council), "safe" (Stock Assessment and
+Fishery Evaluation), "sedar" (SouthEast Data, Assessment, and Review)}
 
 \item{office}{Regional Fisheries Science Center producing the report.
 

--- a/man/create_template.Rd
+++ b/man/create_template.Rd
@@ -43,7 +43,7 @@ Default: "sar" (a NOAA standard "Stock Assessment Report")
 
 Options: "sar" (Stock Assessment Report), "nemt" (Northeast Management Track),
 "pfmc" (Pacific Fishery Management Council), "safe" (Stock Assessment and
-Fishery Evaluation), "sedar" (SouthEast Data, Assessment, and Review)}
+Fishery Evaluation)}
 
 \item{office}{Regional Fisheries Science Center producing the report.
 

--- a/man/create_title.Rd
+++ b/man/create_title.Rd
@@ -21,7 +21,7 @@ Default: "sar" (a NOAA standard "Stock Assessment Report")
 
 Options: "sar" (Stock Assessment Report), "nemt" (Northeast Management Track),
 "pfmc" (Pacific Fishery Management Council), "safe" (Stock Assessment and
-Fishery Evaluation), "sedar" (SouthEast Data, Assessment, and Review)}
+Fishery Evaluation)}
 
 \item{office}{Regional Fisheries Science Center producing the report.
 

--- a/man/create_title.Rd
+++ b/man/create_title.Rd
@@ -19,7 +19,9 @@ create_title(
 
 Default: "sar" (a NOAA standard "Stock Assessment Report")
 
-Options: "sar" (Stock Assessment Report), "nemt" (Northeast Management Track), "pfmc" (Pacific Fishery Management Council), "safe" (Stock Assessment and Fishery Evaluation)}
+Options: "sar" (Stock Assessment Report), "nemt" (Northeast Management Track),
+"pfmc" (Pacific Fishery Management Council), "safe" (Stock Assessment and
+Fishery Evaluation), "sedar" (SouthEast Data, Assessment, and Review)}
 
 \item{office}{Regional Fisheries Science Center producing the report.
 

--- a/man/create_title.Rd
+++ b/man/create_title.Rd
@@ -21,7 +21,7 @@ Default: "sar" (a NOAA standard "Stock Assessment Report")
 
 Options: "sar" (Stock Assessment Report), "nemt" (Northeast Management Track),
 "pfmc" (Pacific Fishery Management Council), "safe" (Stock Assessment and
-Fishery Evaluation)}
+Fishery Evaluation), "sedar" (SouthEast Data, Assessment, and Review)}
 
 \item{office}{Regional Fisheries Science Center producing the report.
 

--- a/man/create_yaml.Rd
+++ b/man/create_yaml.Rd
@@ -107,7 +107,9 @@ Default: NULL}
 
 Default: "sar" (a NOAA standard "Stock Assessment Report")
 
-Options: "sar" (Stock Assessment Report), "nemt" (Northeast Management Track), "pfmc" (Pacific Fishery Management Council), "safe" (Stock Assessment and Fishery Evaluation)}
+Options: "sar" (Stock Assessment Report), "nemt" (Northeast Management Track),
+"pfmc" (Pacific Fishery Management Council), "safe" (Stock Assessment and
+Fishery Evaluation), "sedar" (SouthEast Data, Assessment, and Review)}
 }
 \value{
 Create a string indicating the important formatting pieces for a

--- a/man/create_yaml.Rd
+++ b/man/create_yaml.Rd
@@ -109,7 +109,7 @@ Default: "sar" (a NOAA standard "Stock Assessment Report")
 
 Options: "sar" (Stock Assessment Report), "nemt" (Northeast Management Track),
 "pfmc" (Pacific Fishery Management Council), "safe" (Stock Assessment and
-Fishery Evaluation), "sedar" (SouthEast Data, Assessment, and Review)}
+Fishery Evaluation)}
 }
 \value{
 Create a string indicating the important formatting pieces for a

--- a/man/create_yaml.Rd
+++ b/man/create_yaml.Rd
@@ -109,7 +109,7 @@ Default: "sar" (a NOAA standard "Stock Assessment Report")
 
 Options: "sar" (Stock Assessment Report), "nemt" (Northeast Management Track),
 "pfmc" (Pacific Fishery Management Council), "safe" (Stock Assessment and
-Fishery Evaluation)}
+Fishery Evaluation), "sedar" (SouthEast Data, Assessment, and Review)}
 }
 \value{
 Create a string indicating the important formatting pieces for a

--- a/man/format_quarto.Rd
+++ b/man/format_quarto.Rd
@@ -20,7 +20,7 @@ Default: "sar" (a NOAA standard "Stock Assessment Report")
 
 Options: "sar" (Stock Assessment Report), "nemt" (Northeast Management Track),
 "pfmc" (Pacific Fishery Management Council), "safe" (Stock Assessment and
-Fishery Evaluation)}
+Fishery Evaluation), "sedar" (SouthEast Data, Assessment, and Review)}
 }
 \value{
 This function returns part of a quarto YAML header

--- a/man/format_quarto.Rd
+++ b/man/format_quarto.Rd
@@ -18,7 +18,9 @@ Options: "pdf", "html"}
 
 Default: "sar" (a NOAA standard "Stock Assessment Report")
 
-Options: "sar" (Stock Assessment Report), "nemt" (Northeast Management Track), "pfmc" (Pacific Fishery Management Council), "safe" (Stock Assessment and Fishery Evaluation)}
+Options: "sar" (Stock Assessment Report), "nemt" (Northeast Management Track),
+"pfmc" (Pacific Fishery Management Council), "safe" (Stock Assessment and
+Fishery Evaluation), "sedar" (SouthEast Data, Assessment, and Review)}
 }
 \value{
 This function returns part of a quarto YAML header

--- a/man/format_quarto.Rd
+++ b/man/format_quarto.Rd
@@ -20,7 +20,7 @@ Default: "sar" (a NOAA standard "Stock Assessment Report")
 
 Options: "sar" (Stock Assessment Report), "nemt" (Northeast Management Track),
 "pfmc" (Pacific Fishery Management Council), "safe" (Stock Assessment and
-Fishery Evaluation), "sedar" (SouthEast Data, Assessment, and Review)}
+Fishery Evaluation)}
 }
 \value{
 This function returns part of a quarto YAML header

--- a/tests/testthat/test-create_citation.R
+++ b/tests/testthat/test-create_citation.R
@@ -7,8 +7,20 @@ test_that("citation generated properly for SWFSC", {
       "Kevin T. Hill" = "SWFSC"
     ),
     title = "Check",
-    year = 2024
+    year = 2024,
+    type = "SAR"
   )
   expected_output <- "{{< pagebreak >}} \n\nPlease cite this publication as: \n\nKuriyama, P. T., Allen Akselrud, C., Zwolinski, J. P., and Hill, K. T. 2024. Check. Pacific Fishery Management Council, Portland, OR. Available from https://www.pcouncil.org/stock-assessments-and-fishery-evaluation-safe-documents/. \\pageref*{LastPage}{} pp."
   expect_equal(fxn_test, expected_output)
 })
+
+test_that("citation generated properly for SEFSC", {
+  fxn_test <- create_citation(
+    type = "sedar",
+    title = "Check",
+    year = 2024
+  )
+  expected_output <- "{{< pagebreak >}} \n\nPlease cite this publication as: \n\nSEDAR. 2024. Check. SEDAR, North Charleston SC. \\pageref*{LastPage}{} pp."
+  expect_equal(fxn_test, expected_output)
+})
+


### PR DESCRIPTION


<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Add new template "type" for SEDAR reports, based off three reports: [SEDAR 72](https://sedarweb.org/documents/sedar-72-gulf-of-mexico-gag-grouper-final-stock-assessment-report_october2021/), [SEDAR 85](https://sedarweb.org/documents/sedar-85-gulf-of-mexico-yellowedge-grouper-final-stock-assessment-report/), [SEDAR 81](https://www.fisheries.noaa.gov/inport/item/71013)
* Update citation-making process so that if type = SEDAR or office = SEFSC, citation is SEDAR-specific

# How have you implemented the solution?
* Updating `create_template()` and `create_yaml()`
* Adding new template for SEDAR to templates folder

# Does the PR impact any other area of the project, maybe another repo?
* No