### PR TITLE
fix: remove extra `.` 

### DIFF
--- a/R/create_citation.R
+++ b/R/create_citation.R
@@ -130,7 +130,7 @@ create_citation <- function(
       {
         # Default
         paste0(
-          ". National Marine Fisheries Service, ",
+          "National Marine Fisheries Service, ",
           "[CITY], [STATE]. "
         )
       }


### PR DESCRIPTION

<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Fixes extra `.` in citation for report
* Addresses issue #494 

# How have you implemented the solution?
* Removes extra `.` when `region_specific_part` is set using the default option

# Does the PR impact any other area of the project, maybe another repo?
* No
