### PR TITLE
[fix] Bug where tables doc header is missing

### DIFF
--- a/R/create_tables_doc.R
+++ b/R/create_tables_doc.R
@@ -63,6 +63,9 @@ create_tables_doc <- function(subdir = getwd(),
 
       # remove empty_doc_text
       updated_content <- gsub(empty_doc_text, "", table_content, fixed = TRUE)
+      if (length(updated_content) >= 3 && updated_content[3] == "") {
+        updated_content <- updated_content[-3]
+      }
       writeLines(updated_content, existing_tables_doc)
     }
   } else {

--- a/R/create_template.R
+++ b/R/create_template.R
@@ -677,13 +677,6 @@ create_template <- function(
         "safe" = "12_tables.qmd",
         "09_tables.qmd"
       )
-      tables_doc <- ""
-      utils::capture.output(cat(tables_doc),
-        file = fs::path(subdir, tables_doc_name),
-        append = FALSE
-      ) |>
-        suppressMessages() |>
-        suppressWarnings()
 
       create_tables_doc(
         subdir = subdir,


### PR DESCRIPTION
# What is the feature?
* Address https://github.com/nmfs-ost/asar/issues/539 bug, where tables doc is missing header when made with create_template()

# How have you implemented the solution?
* Remove chunk of code mentioned in issue

# Does the PR impact any other area of the project, maybe another repo?
* No
