### PR TITLE
[feat] Incorporate executive summary figures and tables into template

### DIFF
--- a/R/create_figures_doc.R
+++ b/R/create_figures_doc.R
@@ -21,6 +21,30 @@ create_figures_doc <- function(subdir = getwd(),
   empty_doc_text <- "Please refer to the `stockplotr` package downloaded from remotes::install_github('nmfs-ost/stockplotr') to add premade figures."
 
   fig_header <- "# Figures {#sec-figures}\n \n"
+  
+  # list all files in figures
+  file_list <- list.files(file.path(figures_dir, "figures"))
+  
+  # create sublist of only rda figure files
+  rda_fig_list <- file_list[grepl("_figure.rda", file_list)]
+  # create list of executive summary figures
+  exec_sum_fig_list <- c("biomass_figure.rda", "fishing_mortality_figure.rda")
+  # create list of executive summary figures in the rda figure list
+  selected_exec_sum_fig_list <- exec_sum_fig_list[exec_sum_fig_list %in% rda_fig_list]
+  
+  # remove exec_sum_fig_list from rda_fig_list
+  if (length(selected_exec_sum_fig_list) > 0) {
+    cli::cli_alert_success("Found {length(selected_exec_sum_fig_list)} Executive Summary figure{?s} in {fs::path(figures_dir, 'figures')}: {paste(selected_exec_sum_fig_list, collapse = ', ')}")
+    rda_fig_list <- rda_fig_list[!rda_fig_list %in% selected_exec_sum_fig_list]
+    if (length(rda_fig_list) == 0) {
+      rda_fig_list <- NULL
+    }
+  } else {
+    selected_exec_sum_fig_list <- NULL
+  }
+  
+  # create sublist of only non-rda figure files
+  non.rda_fig_list <- file_list[!grepl(".rda", file_list)]
 
   # append figure-producing code to non-empty figures doc, if it exists, vs. overwriting it
   append <- FALSE
@@ -28,13 +52,15 @@ create_figures_doc <- function(subdir = getwd(),
     existing_figs_doc <- file.path(subdir, list.files(subdir, pattern = "figures.qmd"))
     figure_content <- readLines(existing_figs_doc) |>
       suppressWarnings()
-    if ("# Figures {#sec-figures}" %in% figure_content) {
+    if ("# Figures {#sec-figures}" %in% figure_content & !is.null(rda_fig_list)) {
       append <- TRUE
       cli::cli_alert_info("Figures doc will be appended to include figures in `figures_dir`.")
 
       # remove empty_doc_text
       updated_content <- gsub(empty_doc_text, "", figure_content, fixed = TRUE)
       writeLines(updated_content, existing_figs_doc)
+    } else {
+      figure_content <- ""
     }
   } else {
     figure_content <- ""
@@ -64,23 +90,6 @@ create_figures_doc <- function(subdir = getwd(),
   }
 
   figures_doc <- ""
-
-  # list all files in figures
-  file_list <- list.files(file.path(figures_dir, "figures"))
-
-  # create sublist of only rda figure files
-  rda_fig_list <- file_list[grepl("_figure.rda", file_list)]
-  # create list of executive summary figures
-  exec_sum_fig_list <- c("biomass_figure.rda", "fishing_mortality_figure.rda")
-  # remove exec_sum_fig_list from rda_fig_list
-  if (any(rda_fig_list %in% exec_sum_fig_list)) {
-    exec_sum_fig_list <- exec_sum_fig_list[exec_sum_fig_list %in% rda_fig_list]
-    cli::cli_alert_info("The following figure{?s} will be excluded from the figures doc because they will be in the Executive Summary: {paste(exec_sum_fig_list, collapse = ', ')}")
-    rda_fig_list <- rda_fig_list[!rda_fig_list %in% exec_sum_fig_list]
-  }
-  
-  # create sublist of only non-rda figure files
-  non.rda_fig_list <- file_list[!grepl(".rda", file_list)]
 
 
   # Check if rda or non-rda already exists and remove from list
@@ -202,12 +211,12 @@ rm(rda)\n
         )
       }
     } else {
-      cli::cli_alert_warning("Found zero figures in an rda format (i.e., .rda) in {fs::path(figures_dir, 'figures')}.",
+      cli::cli_alert_warning("Found zero Figures section figures in an rda format (i.e., .rda) in {fs::path(figures_dir, 'figures')}.",
         wrap = TRUE
       )
     }
     if (length(non.rda_fig_list) > 0) {
-      cli::cli_alert_success("Found {length(non.rda_fig_list)}{ifelse(new_non.rda, ' new ', ' ')}figure{?s} in a non-rda format (e.g., .jpg, .png) in {fs::path(figures_dir, 'figures')}.",
+      cli::cli_alert_success("Found {length(non.rda_fig_list)}{ifelse(new_non.rda, ' new ', ' ')} Figures section figure{?s} in a non-rda format (e.g., .jpg, .png) in {fs::path(figures_dir, 'figures')}.",
         wrap = TRUE
       )
       non.rda_figures_doc <- ""
@@ -233,16 +242,16 @@ rm(rda)\n
         non.rda_figures_doc <- paste0(non.rda_figures_doc, fig_chunk)
       }
     } else {
-      cli::cli_alert_warning("Found zero figure files in a non-rda format (e.g., .jpg, .png) in {fs::path(figures_dir, 'figures')}.",
+      cli::cli_alert_warning("Found zero figures in a non-rda format (e.g., .jpg, .png) in {fs::path(figures_dir, 'figures')}.",
         wrap = TRUE
       )
     }
     
-    if (length(exec_sum_fig_list) > 0) {
+    if (!is.null(selected_exec_sum_fig_list)) {
       es_figures_doc <- ""
-      for (i in seq_along(exec_sum_fig_list)) {
+      for (i in seq_along(selected_exec_sum_fig_list)) {
         fig_chunk <- create_fig_chunks(
-          fig = exec_sum_fig_list[i],
+          fig = selected_exec_sum_fig_list[i],
           figures_dir = figures_dir
         )
         
@@ -302,10 +311,10 @@ rm(rda)\n
   )
   
   # add exec summary figures to ES qmd
-  if (file.exists(fs::path(subdir, "01_executive_summary.qmd"))) {
-  exec_sum <- readLines(fs::path(subdir, "01_executive_summary.qmd"))
-  exec_sum <- sub("<!-- Multiple figures and tables designed for.*", es_figures_doc, exec_sum)
-  writeLines(exec_sum, fs::path(subdir, "01_executive_summary.qmd"))    
+  if (file.exists(fs::path(subdir, "01_executive_summary.qmd")) & !is.null(selected_exec_sum_fig_list)) {
+    exec_sum <- readLines(fs::path(subdir, "01_executive_summary.qmd"))
+    exec_sum <- sub("<!-- Multiple figures and tables designed for.*", es_figures_doc, exec_sum)
+    writeLines(exec_sum, fs::path(subdir, "01_executive_summary.qmd"))    
   }
 
   if (doc_info$using_legacy) {

--- a/R/create_figures_doc.R
+++ b/R/create_figures_doc.R
@@ -195,7 +195,7 @@ rm(rda)\n
   } else {
     # paste rda figure code chunks into one object
     if (length(rda_fig_list) > 0) {
-      cli::cli_alert_success("Found {length(rda_fig_list)}{ifelse(new_rda, ' new ', ' ')}figure{?s} in an rda format (i.e., .rda) in {fs::path(figures_dir, 'figures')}.",
+      cli::cli_alert_success("Found {length(rda_fig_list)}{ifelse(new_rda, ' new ', ' ')} Figures section figure{?s} in an rda format (i.e., .rda) in {fs::path(figures_dir, 'figures')}.",
         wrap = TRUE
       )
       rda_figures_doc <- ""
@@ -313,8 +313,13 @@ rm(rda)\n
   # add exec summary figures to ES qmd
   if (file.exists(fs::path(subdir, "01_executive_summary.qmd")) & !is.null(selected_exec_sum_fig_list)) {
     exec_sum <- readLines(fs::path(subdir, "01_executive_summary.qmd"))
-    exec_sum <- sub("<!-- Multiple figures and tables designed for.*", es_figures_doc, exec_sum)
-    writeLines(exec_sum, fs::path(subdir, "01_executive_summary.qmd"))    
+    placeholder_snippet <- "<!-- Multiple figures and tables designed for"
+    if (any(grepl(placeholder_snippet, exec_sum, fixed = TRUE))) {
+      exec_sum <- sub("<!-- Multiple figures and tables designed for.*", es_figures_doc, exec_sum)      
+    } else {
+      exec_sum <- sub("## Assessment Model {#sec-assessment-model}", paste0(es_figures_doc, "## Assessment Model {#sec-assessment-model}"), exec_sum, fixed = TRUE)       
+    }
+    writeLines(exec_sum, fs::path(subdir, "01_executive_summary.qmd"))
   }
 
   if (doc_info$using_legacy) {

--- a/R/create_figures_doc.R
+++ b/R/create_figures_doc.R
@@ -70,8 +70,18 @@ create_figures_doc <- function(subdir = getwd(),
 
   # create sublist of only rda figure files
   rda_fig_list <- file_list[grepl("_figure.rda", file_list)]
+  # create list of executive summary figures
+  exec_sum_fig_list <- c("biomass_figure.rda", "fishing_mortality_figure.rda")
+  # remove exec_sum_fig_list from rda_fig_list
+  if (any(rda_fig_list %in% exec_sum_fig_list)) {
+    exec_sum_fig_list <- exec_sum_fig_list[exec_sum_fig_list %in% rda_fig_list]
+    cli::cli_alert_info("The following figure{?s} will be excluded from the figures doc because they will be in the Executive Summary: {paste(exec_sum_fig_list, collapse = ', ')}")
+    rda_fig_list <- rda_fig_list[!rda_fig_list %in% exec_sum_fig_list]
+  }
+  
   # create sublist of only non-rda figure files
   non.rda_fig_list <- file_list[!grepl(".rda", file_list)]
+
 
   # Check if rda or non-rda already exists and remove from list
   new_rda <- FALSE
@@ -227,6 +237,33 @@ rm(rda)\n
         wrap = TRUE
       )
     }
+    
+    if (length(exec_sum_fig_list) > 0) {
+      es_figures_doc <- ""
+      for (i in seq_along(exec_sum_fig_list)) {
+        fig_chunk <- create_fig_chunks(
+          fig = exec_sum_fig_list[i],
+          figures_dir = figures_dir
+        )
+        
+        es_figures_doc <- paste0(
+          es_figures_doc, fig_chunk
+         # ,"{{< pagebreak >}} \n\n"
+        )
+      }
+      es_figures_doc <- paste0(
+        # setup chunk
+        paste0(
+          add_chunk(
+            glue::glue("figures_dir <- fs::path('{figures_dir}', 'figures')"),
+            label = "set-rda-dir-figs-es"
+          ),
+          "\n"
+        ),
+        # figure chunks
+        es_figures_doc
+      )
+    }
 
     # combine figures_doc setup with figure chunks
     figures_doc <- paste0(
@@ -263,6 +300,13 @@ rm(rda)\n
     file = fs::path(subdir, figures_doc_name),
     append = append
   )
+  
+  # add exec summary figures to ES qmd
+  if (file.exists(fs::path(subdir, "01_executive_summary.qmd"))) {
+  exec_sum <- readLines(fs::path(subdir, "01_executive_summary.qmd"))
+  exec_sum <- sub("<!-- Multiple figures and tables designed for.*", es_figures_doc, exec_sum)
+  writeLines(exec_sum, fs::path(subdir, "01_executive_summary.qmd"))    
+  }
 
   if (doc_info$using_legacy) {
     file.rename(

--- a/R/create_tables_doc.R
+++ b/R/create_tables_doc.R
@@ -49,6 +49,40 @@ create_tables_doc <- function(subdir = getwd(),
   empty_doc_text <- "Please refer to the `stockplotr` package downloaded from remotes::install_github('nmfs-ost/stockplotr') to add premade tables."
 
   tab_header <- "# Tables {#sec-tables}\n \n"
+  
+  # list all files in tables
+  file_list <- list.files(file.path(tables_dir, "tables"))
+  
+  # create sublist of only rda table files
+  rda_tab_list <- file_list[grepl(".rda", file_list)]
+  
+  if (length(rda_tab_list) == 0) {
+      cli::cli_alert_warning("Found zero tables in an rda format (i.e., .rda) in {fs::path(tables_dir, 'tables')}.",
+                             wrap = TRUE
+      )
+      cli::cli_alert_info("For `create_tables_doc` to incorporate tables, there must be:",
+                          wrap = TRUE
+      )
+      cli::cli_ol(c(
+        "a 'tables' folder in {fs::path(tables_dir)}",
+        ".rda files in the 'tables' folder"
+      ))
+      }
+  # create list of executive summary tables
+  exec_sum_tab_list <- c("projections_table.rda", "total_catch_table.rda")
+  # create list of executive summary tables in the rda table list
+  selected_exec_sum_tab_list <- exec_sum_tab_list[exec_sum_tab_list %in% rda_tab_list]
+  
+  # remove exec_sum_tab_list from rda_tab_list
+  if (length(selected_exec_sum_tab_list) > 0) {
+    cli::cli_alert_success("Found {length(selected_exec_sum_tab_list)} Executive Summary table{?s} in {fs::path(tables_dir, 'tables')}: {paste(selected_exec_sum_tab_list, collapse = ', ')}")
+    rda_tab_list <- rda_tab_list[!rda_tab_list %in% selected_exec_sum_tab_list]
+    if (length(rda_tab_list) == 0) {
+      rda_tab_list <- NULL
+    }
+  } else {
+    selected_exec_sum_tab_list <- NULL
+  }
 
   # append table-producing code to non-empty tables doc, if it exists, vs. overwriting it
   append <- FALSE
@@ -57,7 +91,7 @@ create_tables_doc <- function(subdir = getwd(),
     table_content <- readLines(existing_tables_doc) |>
       suppressWarnings()
 
-    if ("# Tables {#sec-tables}" %in% table_content) {
+    if ("# Tables {#sec-tables}" %in% table_content & !is.null(rda_tab_list)) {
       append <- TRUE
       cli::cli_alert_info("Tables doc will be appended to include tables in `tables_dir`.")
 
@@ -104,12 +138,6 @@ create_tables_doc <- function(subdir = getwd(),
   }
 
   tables_doc <- ""
-
-  # list all files in tables
-  file_list <- list.files(file.path(tables_dir, "tables"))
-
-  # create sublist of only rda table files
-  rda_tab_list <- file_list[grepl(".rda", file_list)]
 
   # Check if rda already exists and remove from list
   # Check if rda or non-rda already exists and remove from list
@@ -502,16 +530,6 @@ load(file.path(tables_dir, '", stringr::str_remove(tab, "_split"), "'))\n
 
   if (length(rda_tab_list) == 0) {
     if (length(file.path(subdir, list.files(subdir, pattern = "tables.qmd"))) != 1) {
-      cli::cli_alert_warning("Found zero tables in an rda format (i.e., .rda) in {fs::path(tables_dir, 'tables')}.",
-        wrap = TRUE
-      )
-      cli::cli_alert_info("For `create_tables_doc` to incorporate tables, there must be:",
-        wrap = TRUE
-      )
-      cli::cli_ol(c(
-        "a 'tables' folder in {fs::path(tables_dir)}",
-        ".rda files in the 'tables' folder"
-      ))
       tables_doc <- paste0(
         tables_doc_header,
         empty_doc_text
@@ -520,7 +538,7 @@ load(file.path(tables_dir, '", stringr::str_remove(tab, "_split"), "'))\n
       cli::cli_alert("No new tables detected.")
     }
   } else {
-    cli::cli_alert_success("Found {length(final_rda_tab_list)}{ifelse(new_rda, ' new ', ' ')}table{?s} in an rda format (i.e., .rda) in {fs::path(tables_dir, 'tables')}.",
+    cli::cli_alert_success("Found {length(final_rda_tab_list)}{ifelse(new_rda, ' new ', ' ')} Tables section table{?s} in an rda format (i.e., .rda) in {fs::path(tables_dir, 'tables')}.",
       wrap = TRUE
     )
     # paste rda table code chunks into one object
@@ -535,28 +553,42 @@ load(file.path(tables_dir, '", stringr::str_remove(tab, "_split"), "'))\n
         rda_tables_doc <- paste0(rda_tables_doc, tab_chunk)
       }
     }
-    # if (length(non.rda_tab_list) > 0){
-    #   non.rda_tables_doc <- ""
-    #   for (i in seq_along(non.rda_tab_list)){
-    #     # remove file extension
-    #     tab_name <- stringr::str_extract(non.rda_tab_list[i],
-    #                                      "^[^.]+")
-    #     # remove "_table", if present
-    #     tab_name <- sub("_table", "", tab_name)
-    #     tab_chunk <- paste0(
-    #       "![Your caption here](", fs::path("tables",
-    #                                         non.rda_tab_list[i]),
-    #       "){#tab-",
-    #       tab_name,
-    #       "}\n\n"
-    #     )
-    #
-    #     non.rda_tables_doc <- paste0(non.rda_tables_doc, tab_chunk)
-    #   }
-    # } else {
-    #   message(paste0("Note: No table files in a non-rda format (e.g., .jpg, .png) were found in '",  fs::path(tables_dir, "tables") , "'."))
-    # }
-
+    }
+  if (!is.null(selected_exec_sum_tab_list)) {
+    es_tables_doc <- ""
+    for (i in seq_along(selected_exec_sum_tab_list)) {
+      tab_chunk <- create_tab_chunks(
+        tab = selected_exec_sum_tab_list[i],
+        tables_dir = tables_dir
+      )
+      
+      es_tables_doc <- paste0(
+        es_tables_doc, tab_chunk
+        # ,"{{< pagebreak >}} \n\n"
+      )
+    }
+    es_tables_doc <- paste0(
+      # setup chunk
+      paste0(
+        add_chunk(
+          glue::glue(
+            "library(gt)
+          tables_dir <- fs::path('{tables_dir}', 'tables')"
+          ),
+          label = "set-rda-dir-tbls-es",
+          chunk_option = c(
+            "echo: false",
+            "warning: false",
+            "include: false"
+          )
+        ),
+        "\n"
+      ),
+      # table chunks
+      es_tables_doc
+    )
+  }
+    
     # combine tables_doc setup with table chunks
     tables_doc <- paste0(
       tables_doc_header,
@@ -566,6 +598,17 @@ load(file.path(tables_dir, '", stringr::str_remove(tab, "_split"), "'))\n
         ""
       )
     )
+  
+  # add exec summary tables to ES qmd
+  if (file.exists(fs::path(subdir, "01_executive_summary.qmd")) & !is.null(selected_exec_sum_tab_list)) {
+    exec_sum <- readLines(fs::path(subdir, "01_executive_summary.qmd"))
+    placeholder_snippet <- "<!-- Multiple figures and tables designed for"
+    if (any(grepl(placeholder_snippet, exec_sum, fixed = TRUE))) {
+      exec_sum <- sub("<!-- Multiple figures and tables designed for.*", es_tables_doc, exec_sum)      
+    } else {
+      exec_sum <- sub("## Assessment Model {#sec-assessment-model}", paste0(es_tables_doc, "## Assessment Model {#sec-assessment-model}"), exec_sum, fixed = TRUE)       
+    }
+    writeLines(exec_sum, fs::path(subdir, "01_executive_summary.qmd"))
   }
 
   doc_info <- migrate_legacy_docs(subdir, doc_type = "tables")

--- a/tests/testthat/_snaps/create_figures_doc.md
+++ b/tests/testthat/_snaps/create_figures_doc.md
@@ -8,27 +8,27 @@
       #| warnings: false 
       #| eval: true
       # load rda
-      load(file.path(figures_dir, 'biomass_figure.rda'))
+      load(file.path(figures_dir, 'landings_figure.rda'))
       
       # save rda with plot-specific name
-      biomass_plot_rda <- rda
+      landings_plot_rda <- rda
       
       # remove generic rda object
       rm(rda)
       
       # save figure, caption, and alt text as separate objects
-      biomass_plot <- biomass_plot_rda$figure
-      biomass_cap <- biomass_plot_rda$caption
-      biomass_alt_text <- biomass_plot_rda$alt_text
+      landings_plot <- landings_plot_rda$figure
+      landings_cap <- landings_plot_rda$caption
+      landings_alt_text <- landings_plot_rda$alt_text
       ``` 
       
       ```{r} 
-      #| label: 'fig-biomass'
+      #| label: 'fig-landings'
       #| echo: false 
       #| warning: false 
-      #| fig-cap: !expr biomass_cap 
-      #| fig-alt: !expr biomass_alt_text
-      biomass_plot
+      #| fig-cap: !expr landings_cap 
+      #| fig-alt: !expr landings_alt_text
+      landings_plot
       ``` 
       
       {{< pagebreak >}} 

--- a/tests/testthat/test-create_figures_doc.R
+++ b/tests/testthat/test-create_figures_doc.R
@@ -82,7 +82,7 @@ test_that("Formerly empty figures doc renders correctly", {
   # read in figures doc
   figure_content <- readLines(file.path(getwd(), "report", "08_figures.qmd"))
   # extract first 7 lines
-  head_figure_content <- head(figure_content, 7)
+  head_figure_content <- head(figure_content, 6)
   # remove line numbers and collapse
   fc_pasted <- paste(head_figure_content, collapse = "")
 
@@ -134,7 +134,7 @@ test_that("Formerly empty figures doc renders correctly", {
 # DO NOT RERUN MANUALLY -- snapshot path will not be correct if it adjusts and test will fail
 test_that("Adds new figure from figures folder.", {
   # Create one figure
-  stockplotr::plot_biomass(
+  stockplotr::plot_landings(
     dat = stockplotr::example_data,
     make_rda = TRUE,
     module = "TIME_SERIES"


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.
-->

# What is the feature?
* Incorporate executive summary figures and tables into template as per https://github.com/nmfs-ost/asar/issues/404

# How have you implemented the solution?
* Adjusting `create_figures_doc()` and `create_tables_doc()` to look for exec sum figures/tables and put them into the ES rather than the figures/tables docs

# Does the PR impact any other area of the project, maybe another repo?
* No